### PR TITLE
Update Cargo.lock, nifzenoh version from 0.1.3 to 0.1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Zenohex is the [zenoh](https://zenoh.io/) client library for elixir.
 
-Currently zenohex uses version 0.7.0-rc of zenoh.
+Currently zenohex uses version 0.10.1-rc of zenoh.
 If you want to communicate with Rust version of Zenoh, please use the same version. 
 
 ## Installation

--- a/native/nifzenoh/Cargo.lock
+++ b/native/nifzenoh/Cargo.lock
@@ -1188,7 +1188,7 @@ dependencies = [
 
 [[package]]
 name = "nifzenoh"
-version = "0.1.3"
+version = "0.1.5"
 dependencies = [
  "async-std",
  "clap",


### PR DESCRIPTION
This patch is for main branch, i found the lock file line which is updated but isn't commited yet. Maybe developer forgot to commit it.