### PR TITLE
Move Examples docs to lib/zenohex/examples/README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,18 +63,9 @@ iex(6)> Zenohex.Subscriber.recv_timeout(subscriber, 1000)
 
 ### Practical examples
 
-We implemented following practical examples under the [lib/zenohex/examples](lib/zenohex/examples) with moduledoc.
+We implemented practical examples under the [lib/zenohex/examples](https://github.com/b5g-ex/zenohex/tree/v0.2.0-rc.2/lib/zenohex/examples).
 
-(from hexdocs please refer to MODULES tab's EXAMPLE section)
-
-- [Publisher](lib/zenohex/examples/publisher.ex)
-- [Subscriber](lib/zenohex/examples/subscriber.ex)
-- [PullSubscriber](lib/zenohex/examples/pull_subscriber.ex)
-- [Session](lib/zenohex/examples/session.ex)
-- [Queryable](lib/zenohex/examples/queryable.ex)
-- [Storage](lib/zenohex/examples/storage.ex)
-
-Use them as reference for your implementation.
+Please read the [lib/zenohex/examples/README.md](https://github.com/b5g-ex/zenohex/tree/v0.2.0-rc.2/lib/zenohex/examples/README.md) to use them as your implementation's reference.
 
 ## For developer
 

--- a/lib/zenohex/examples/README.md
+++ b/lib/zenohex/examples/README.md
@@ -118,7 +118,36 @@ iex> PullSubscriber.pull()
 12:16:47.306 [debug] %Zenohex.Sample{key_expr: "zenohex/examples/pub", value: "subscribed?", kind: :put, reference: #Reference<0.662543409.1019347013.179304>}
 ```
 
-### Queryable
+## Queryable
+
+This Queryable is made of `Supervisor` and `GenServer`.
+If you would like to see the codes, check the followings.
+
+- Supervisor
+  - [lib/zenohex/examples/queryable.ex](/lib/zenohex/examples/queryable.ex)
+- GenServer
+  - [lib/zenohex/examples/queryable/impl.ex](/lib/zenohex/examples/queryable/impl.ex)
+
+### Start Queryable
+
+```elixir
+iex> alias Zenohex.Examples.Queryable
+# if not specify session, key_expr and callback, they are made internally. key_expr is "zenohex/examples/**", callback is &Logger.debug(inspect(&1))
+iex> Queryable.start_link()
+# you can also inject your session, key_expr and callback from outside
+iex> Queryable.start_link(%{session: your_session, key_expr: "your_key/expression/**", callback: &IO.inspect/1})
+```
+
+### Queried?
+
+```elixir
+iex> alias Zenohex.Examples.Session
+iex> Session.start_link()
+iex> Session.get("zenohex/examples/get", &IO.inspect/1)
+:ok
+
+15:20:17.870 [debug] %Zenohex.Query{key_expr: "zenohex/examples/get", parameters: "", value: :undefined, reference: #Reference<0.3076585362.3463839816.144434>}
+```
 
 ### Session
 

--- a/lib/zenohex/examples/README.md
+++ b/lib/zenohex/examples/README.md
@@ -54,7 +54,36 @@ iex> Publisher.priority(:real_time)
 
 see. Supported options, [Zenohex.Publisher.Options](/lib/zenohex/publisher.ex)
 
-### Subscriber
+## Subscriber
+
+This Subscriber is made of `Supervisor` and `GenServer`.
+If you would like to see the codes, check the followings.
+
+- Supervisor
+  - [lib/zenohex/examples/subscriber.ex](/lib/zenohex/examples/subscriber.ex)
+- GenServer
+  - [lib/zenohex/examples/subscriber/impl.ex](/lib/zenohex/examples/subscriber/impl.ex)
+
+### Start Subscriber
+
+```elixir
+iex> alias Zenohex.Examples.Subscriber
+# if not specify session, key_expr and callback, they are made internally. key_expr is "zenohex/examples/**",callback is &Logger.debug(inspect(&1))
+iex> Subscriber.start_link()
+# you can also inject your session, key_expr and callback from outside
+iex> Subscriber.start_link(%{session: your_session, key_expr: "your_key/expression/**", callback: &IO.inspect/1})
+```
+
+### Subscribed?
+
+```elixir
+iex> alias Zenohex.Examples.Publisher
+iex> Publisher.start_link()
+iex> Publisher.put("subscribed?")
+:ok
+
+11:51:53.959 [debug] %Zenohex.Sample{key_expr: "zenohex/examples/pub", value: "subscribed?", kind: :put, reference: #Reference<0.1373489635.746717252.118288>}
+```
 
 ### PullSubscriber
 

--- a/lib/zenohex/examples/README.md
+++ b/lib/zenohex/examples/README.md
@@ -1,0 +1,65 @@
+# Zenohex.Examples
+
+This README shows how to use following each example implementations.
+
+- [Zenohex.Examples.Publisher](#publisher)
+- [Zenohex.Examples.Subscriber](#subscriber)
+- [Zenohex.Examples.PullSubscriber](#pullsubscriber)
+- [Zenohex.Examples.Queryable](#queryable)
+- [Zenohex.Examples.Session](#session)
+- [Zenohex.Examples.Storage](#storage)
+
+## Publisher
+
+This Publisher is made of `Supervisor` and `GenServer`.
+If you would like to see the codes, check the followings.
+
+- Supervisor
+  - [/lib/zenohex/examples/publisher.ex](/lib/zenohex/examples/publisher.ex)
+- GenServer
+  - [/lib/zenohex/examples/publisher/impl.ex](/lib/zenohex/examples/publisher/impl.ex)
+
+### Start Publisher
+
+```elixir
+iex> alias Zenohex.Examples.Publisher
+# if not specify session and key_expr, they are made internally. key_expr is "zenohex/examples/pub"
+iex> Publisher.start_link()
+# you can also inject your session and key_expr from outside
+iex> Publisher.start_link(%{session: your_session, key_expr: "your_key/expression"})
+```
+
+### Put data
+
+```elixir
+iex> Publisher.put(42)    # integer
+iex> Publisher.put(42.42) # float
+iex> Publisher.put("42")  # binary
+```
+
+### Delete data
+
+```elixir
+iex> Publisher.delete()
+```
+
+see. [#16](https://github.com/b5g-ex/zenohex/issues/16)
+
+### Change Publisher options
+
+```elixir
+iex> Publisher.congestion_control(:block)
+iex> Publisher.priority(:real_time)
+```
+
+see. Supported options, [Zenohex.Publisher.Options](/lib/zenohex/publisher.ex)
+
+### Subscriber
+
+### PullSubscriber
+
+### Queryable
+
+### Session
+
+### Storage

--- a/lib/zenohex/examples/README.md
+++ b/lib/zenohex/examples/README.md
@@ -191,4 +191,47 @@ iex> callback = &IO.inspect/1
 iex> Session.get("zenoh/example/session/get", callback)
 ```
 
-### Storage
+## Storage
+
+This Storage is made of `Supervisor` and `GenServer`.
+If you would like to see the codes, check the followings.
+
+- Supervisor
+  - [lib/zenohex/examples/storage.ex](/lib/zenohex/examples/storage.ex)
+- GenServer
+  - [lib/zenohex/examples/storage/store.ex](/lib/zenohex/examples/storage/store.ex)
+  - [lib/zenohex/examples/storage/subscriber.ex](/lib/zenohex/examples/storage/subscriber.ex)
+  - [lib/zenohex/examples/storage/queryable.ex](/lib/zenohex/examples/storage/queryable.ex)
+
+In this example, we made store with `Agent`. We think we can use also `:ets`, `:dets` and `:mnesia`.
+
+### Start Storage
+
+```elixir
+iex> alias Zenohex.Examples.Storage
+# if not specify session, key_expr and callback, they are made internally. key_expr is "zenohex/examples/**"
+iex> Storage.start_link()
+# you can also inject your session, key_expr and callback from outside
+iex> Storage.start_link(%{session: your_session, key_expr: "your_key/expression/**"})
+```
+
+### Session put/get/delete data with Storage
+
+```elixir
+iex> alias Zenohex.Examples.Session
+iex> Session.start_link()
+iex> Session.put("zenoh/examples/storage", _value = "put")
+:ok
+iex> Session.get("zenoh/examples/storage", _callback = &IO.inspect/1)
+:ok
+%Zenohex.Sample{
+  key_expr: "zenohex/examples/storage",
+  value: "put",
+  kind: :put,
+  reference: #Reference<0.2244884903.1591869505.81651>
+}
+iex> Session.delete("zenoh/examples/storage")
+:ok
+iex> Session.get("zenoh/examples/storage", &IO.inspect/1)
+:ok
+```

--- a/lib/zenohex/examples/README.md
+++ b/lib/zenohex/examples/README.md
@@ -149,6 +149,46 @@ iex> Session.get("zenohex/examples/get", &IO.inspect/1)
 15:20:17.870 [debug] %Zenohex.Query{key_expr: "zenohex/examples/get", parameters: "", value: :undefined, reference: #Reference<0.3076585362.3463839816.144434>}
 ```
 
-### Session
+## Session
+
+This Session is made of `Supervisor` and `GenServer`.
+If you would like to see the codes, check the followings.
+
+- Supervisor
+  - [lib/zenohex/examples/session.ex](/lib/zenohex/examples/session.ex)
+- GenServer
+  - [lib/zenohex/examples/session/impl.ex](/lib/zenohex/examples/session/impl.ex)
+
+### Start Session
+
+```elixir
+iex> alias Zenohex.Examples.Session
+# if not specify session, it is made internally
+iex> Session.start_link()
+# you can also inject your session and key_expr from outside
+iex> Session.start_link(%{session: your_session})
+```
+
+### Put data
+
+```elixir
+iex> Session.put("zenoh/example/session/put", 42)    # integer
+iex> Session.put("zenoh/example/session/put", 42.42) # float
+iex> Session.put("zenoh/example/session/put", "42")  # binary
+```
+
+### Delete data
+
+```elixir
+iex> Session.delete("zenoh/example/session/put")
+iex> Session.delete("zenoh/example/session/**")
+```
+
+### Get data
+
+```elixir
+iex> callback = &IO.inspect/1
+iex> Session.get("zenoh/example/session/get", callback)
+```
 
 ### Storage

--- a/lib/zenohex/examples/README.md
+++ b/lib/zenohex/examples/README.md
@@ -85,7 +85,38 @@ iex> Publisher.put("subscribed?")
 11:51:53.959 [debug] %Zenohex.Sample{key_expr: "zenohex/examples/pub", value: "subscribed?", kind: :put, reference: #Reference<0.1373489635.746717252.118288>}
 ```
 
-### PullSubscriber
+## PullSubscriber
+
+This PullSubscriber is made of `Supervisor` and `GenServer`.
+If you would like to see the codes, check the followings.
+
+- Supervisor
+  - [lib/zenohex/examples/pull_subscriber.ex](/lib/zenohex/examples/pull_subscriber.ex)
+- GenServer
+  - [lib/zenohex/examples/pull_subscriber/impl.ex](/lib/zenohex/examples/pull_subscriber/impl.ex)
+
+### Start PullSubscriber
+
+```elixir
+iex> alias Zenohex.Examples.PullSubscriber
+# if not specify session, key_expr and callback, they are made internally. key_expr is "zenohex/examples/**",callback is &Logger.debug(inspect(&1))
+iex> PullSubscriber.start_link()
+# you can also inject your session, key_expr and callback from outside
+iex> PullSubscriber.start_link(%{session: your_session, key_expr: "your_key/expression/**", callback: &IO.inspect/1})
+```
+
+### Pull data
+
+```elixir
+iex> alias Zenohex.Examples.Publisher
+iex> Publisher.start_link()
+iex> Publisher.put("subscribed?")
+:ok
+iex> PullSubscriber.pull()
+:ok
+
+12:16:47.306 [debug] %Zenohex.Sample{key_expr: "zenohex/examples/pub", value: "subscribed?", kind: :put, reference: #Reference<0.662543409.1019347013.179304>}
+```
 
 ### Queryable
 

--- a/lib/zenohex/examples/publisher.ex
+++ b/lib/zenohex/examples/publisher.ex
@@ -1,54 +1,11 @@
 defmodule Zenohex.Examples.Publisher do
-  mix_config = Mix.Project.config()
-  version = mix_config[:version]
-  base_url = "https://github.com/b5g-ex/zenohex/tree/v#{version}/lib/examples"
-
-  @moduledoc """
-  This is the example Publisher implementation using Zenohex.
-
-  This Publisher is made of `m:Supervisor` and `m:GenServer`.
-  If you would like to see the codes, check the followings.
-
-    * Supervisor
-      * [lib/zenohex/examples/publisher.ex](#{base_url}/publisher.ex)
-    * GenServer
-      * [lib/zenohex/examples/publisher/impl.ex](#{base_url}/publisher/impl.ex)
-
-  ## Getting Started
-
-  ### Start Publisher
-
-      iex> alias Zenohex.Examples.Publisher
-      # if not specify session and key_expr, they are made internally. key_expr is "zenohex/examples/pub"
-      iex> Publisher.start_link()
-      # you can also inject your session and key_expr from outside
-      iex> Publisher.start_link(%{session: your_session, key_expr: "your_key/expression"})
-
-  ### Put data
-
-      iex> Publisher.put(42)    # integer
-      iex> Publisher.put(42.42) # float
-      iex> Publisher.put("42")  # binary
-
-  ### Delete data
-
-      iex> Publisher.delete()
-
-  ### Change Publisher options
-
-      iex> Publisher.congestion_control(:block)
-      iex> Publisher.priority(:real_time)
-
-  see. Supported options, `m:Zenohex.Publisher.Options`
-  """
+  @moduledoc false
 
   use Supervisor
 
   alias Zenohex.Examples.Publisher
 
-  @doc """
-  Start Publisher.
-  """
+  @doc "Start Publisher."
   def start_link(args \\ %{}) when is_map(args) do
     session = Map.get(args, :session) || Zenohex.open!()
     key_expr = Map.get(args, :key_expr, "zenohex/examples/pub")

--- a/lib/zenohex/examples/pull_subscriber.ex
+++ b/lib/zenohex/examples/pull_subscriber.ex
@@ -1,40 +1,5 @@
 defmodule Zenohex.Examples.PullSubscriber do
-  mix_config = Mix.Project.config()
-  version = mix_config[:version]
-  base_url = "https://github.com/b5g-ex/zenohex/tree/v#{version}/lib/examples"
-
-  @moduledoc """
-  This is the example PullSubscriber implementation using Zenohex.
-
-  This PullSubscriber is made of `m:Supervisor` and `m:GenServer`.
-  If you would like to see the codes, check the followings.
-
-    * Supervisor
-      * [lib/zenohex/examples/pull_subscriber.ex](#{base_url}/pull_subscriber.ex)
-    * GenServer
-      * [lib/zenohex/examples/pull_subscriber/impl.ex](#{base_url}/pull_subscriber/impl.ex)
-
-  ## Getting Started
-
-  ### Start PullSubscriber
-
-      iex> alias Zenohex.Examples.PullSubscriber
-      # if not specify session, key_expr and callback, they are made internally. key_expr is "zenohex/examples/**",callback is &Logger.debug(inspect(&1))
-      iex> PullSubscriber.start_link()
-      # you can also inject your session, key_expr and callback from outside
-      iex> PullSubscriber.start_link(%{session: your_session, key_expr: "your_key/expression/**", callback: &IO.inspect/1})
-
-  ### Pull data
-
-      iex> alias Zenohex.Examples.Publisher
-      iex> Publisher.start_link()
-      iex> Publisher.put("subscribed?")
-      :ok
-      iex> PullSubscriber.pull()
-      :ok
-      
-      12:16:47.306 [debug] %Zenohex.Sample{key_expr: "zenohex/examples/pub", value: "subscribed?", kind: :put, reference: #Reference<0.662543409.1019347013.179304>}
-  """
+  @moduledoc false
 
   use Supervisor
 
@@ -42,9 +7,7 @@ defmodule Zenohex.Examples.PullSubscriber do
 
   alias Zenohex.Examples.PullSubscriber
 
-  @doc """
-  Start PullSubscriber.
-  """
+  @doc "Start PullSubscriber."
   def start_link(args \\ %{}) when is_map(args) do
     session = Map.get(args, :session) || Zenohex.open!()
     key_expr = Map.get(args, :key_expr, "zenohex/examples/**")

--- a/lib/zenohex/examples/queryable.ex
+++ b/lib/zenohex/examples/queryable.ex
@@ -1,38 +1,5 @@
 defmodule Zenohex.Examples.Queryable do
-  mix_config = Mix.Project.config()
-  version = mix_config[:version]
-  base_url = "https://github.com/b5g-ex/zenohex/tree/v#{version}/lib/examples"
-
-  @moduledoc """
-  This is the example Queryable implementation using Zenohex.
-
-  This Queryable is made of `m:Supervisor` and `m:GenServer`.
-  If you would like to see the codes, check the followings.
-
-    * Supervisor
-      * [lib/zenohex/examples/queryable.ex](#{base_url}/queryable.ex)
-    * GenServer
-      * [lib/zenohex/examples/queryable/impl.ex](#{base_url}/queryable/impl.ex)
-
-  ## Getting Started
-
-  ### Start Queryable
-
-      iex> alias Zenohex.Examples.Queryable
-      # if not specify session, key_expr and callback, they are made internally. key_expr is "zenohex/examples/**", callback is &Logger.debug(inspect(&1))
-      iex> Queryable.start_link()
-      # you can also inject your session, key_expr and callback from outside
-      iex> Queryable.start_link(%{session: your_session, key_expr: "your_key/expression/**", callback: &IO.inspect/1})
-
-  ### Queried?
-
-      iex> alias Zenohex.Examples.Session
-      iex> Session.start_link()
-      iex> Session.get("zenohex/examples/get", &IO.inspect/1)
-      :ok
-      
-      15:20:17.870 [debug] %Zenohex.Query{key_expr: "zenohex/examples/get", parameters: "", value: :undefined, reference: #Reference<0.3076585362.3463839816.144434>}
-  """
+  @moduledoc false
 
   use Supervisor
 
@@ -40,9 +7,7 @@ defmodule Zenohex.Examples.Queryable do
 
   alias Zenohex.Examples.Queryable
 
-  @doc """
-  Start Queryable.
-  """
+  @doc "Start Queryable."
   def start_link(args \\ %{}) when is_map(args) do
     session = Map.get(args, :session) || Zenohex.open!()
     key_expr = Map.get(args, :key_expr, "zenohex/examples/**")

--- a/lib/zenohex/examples/session.ex
+++ b/lib/zenohex/examples/session.ex
@@ -1,54 +1,11 @@
 defmodule Zenohex.Examples.Session do
-  mix_config = Mix.Project.config()
-  version = mix_config[:version]
-  base_url = "https://github.com/b5g-ex/zenohex/tree/v#{version}/lib/examples"
-
-  @moduledoc """
-  This is the example Session implementation using Zenohex.
-
-  This Session is made of `m:Supervisor` and `m:GenServer`.
-  If you would like to see the codes, check the followings.
-
-    * Supervisor
-      * [lib/zenohex/examples/session.ex](#{base_url}/session.ex)
-    * GenServer
-      * [lib/zenohex/examples/session/impl.ex](#{base_url}/session/impl.ex)
-
-  ## Getting Started
-
-  ### Start Session
-
-      iex> alias Zenohex.Examples.Session
-      # if not specify session, it is made internally
-      iex> Session.start_link()
-      # you can also inject your session and key_expr from outside
-      iex> Session.start_link(%{session: your_session})
-
-  ### Put data
-
-      iex> Session.put("zenoh/example/session/put", 42)    # integer
-      iex> Session.put("zenoh/example/session/put", 42.42) # float
-      iex> Session.put("zenoh/example/session/put", "42")  # binary
-
-  ### Delete data
-
-      iex> Session.delete("zenoh/example/session/put")
-      iex> Session.delete("zenoh/example/session/**")
-
-  ### Get data
-
-      iex> callback = &IO.inspect/1
-      iex> Session.get("zenoh/example/session/get", callback)
-
-  """
+  @moduledoc false
 
   use Supervisor
 
   alias Zenohex.Examples.Session
 
-  @doc """
-  Start Session.
-  """
+  @doc "Start Session."
   def start_link(args \\ %{}) when is_map(args) do
     session = Map.get(args, :session) || Zenohex.open!()
     Supervisor.start_link(__MODULE__, %{session: session}, name: __MODULE__)

--- a/lib/zenohex/examples/storage.ex
+++ b/lib/zenohex/examples/storage.ex
@@ -1,60 +1,11 @@
 defmodule Zenohex.Examples.Storage do
-  mix_config = Mix.Project.config()
-  version = mix_config[:version]
-  base_url = "https://github.com/b5g-ex/zenohex/tree/v#{version}/lib/examples"
-
-  @moduledoc """
-  This is the example Storage implementation using Zenohex.
-
-  This Storage is made of `m:Supervisor` and `m:GenServer`.
-  If you would like to see the codes, check the followings.
-
-    * Supervisor
-      * [lib/zenohex/examples/storage.ex](#{base_url}/storage.ex)
-    * GenServer
-      * [lib/zenohex/examples/storage/store.ex](#{base_url}/storage/store.ex)
-      * [lib/zenohex/examples/storage/subscriber.ex](#{base_url}/storage/subscriber.ex)
-      * [lib/zenohex/examples/storage/queryable.ex](#{base_url}/storage/queryable.ex)
-
-  In this example, we made store with `m:Agent`. We think we can use also `:ets`, `:dets` and `:mnesia`.
-
-  ## Getting Started
-
-  ### Start Storage
-
-      iex> alias Zenohex.Examples.Storage
-      # if not specify session, key_expr and callback, they are made internally. key_expr is "zenohex/examples/**"
-      iex> Storage.start_link()
-      # you can also inject your session, key_expr and callback from outside
-      iex> Storage.start_link(%{session: your_session, key_expr: "your_key/expression/**"})
-
-  ### Session put/get/delete data with Storage
-
-      iex> alias Zenohex.Examples.Session
-      iex> Session.start_link()
-      iex> Session.put("zenoh/examples/storage", _value = "put")
-      :ok
-      iex> Session.get("zenoh/examples/storage", _callback = &IO.inspect/1)
-      :ok
-      %Zenohex.Sample{
-        key_expr: "zenohex/examples/storage",
-        value: "put",
-        kind: :put,
-        reference: #Reference<0.2244884903.1591869505.81651>
-      }
-      iex> Session.delete("zenoh/examples/storage")
-      :ok
-      iex> Session.get("zenoh/examples/storage", &IO.inspect/1)
-      :ok
-  """
+  @moduledoc false
 
   use Supervisor
 
   alias Zenohex.Examples.Storage
 
-  @doc """
-  Start storage.
-  """
+  @doc "Start storage."
   def start_link(args \\ %{}) when is_map(args) do
     session = Map.get(args, :session) || Zenohex.open!()
     key_expr = Map.get(args, :key_expr, "zenohex/examples/**")

--- a/lib/zenohex/examples/subscriber.ex
+++ b/lib/zenohex/examples/subscriber.ex
@@ -1,38 +1,5 @@
 defmodule Zenohex.Examples.Subscriber do
-  mix_config = Mix.Project.config()
-  version = mix_config[:version]
-  base_url = "https://github.com/b5g-ex/zenohex/tree/v#{version}/lib/examples"
-
-  @moduledoc """
-  This is the example Subscriber implementation using Zenohex.
-
-  This Subscriber is made of `m:Supervisor` and `m:GenServer`.
-  If you would like to see the codes, check the followings.
-
-    * Supervisor
-      * [lib/zenohex/examples/subscriber.ex](#{base_url}/subscriber.ex)
-    * GenServer
-      * [lib/zenohex/examples/subscriber/impl.ex](#{base_url}/subscriber/impl.ex)
-
-  ## Getting Started
-
-  ### Start Subscriber
-
-      iex> alias Zenohex.Examples.Subscriber
-      # if not specify session, key_expr and callback, they are made internally. key_expr is "zenohex/examples/**",callback is &Logger.debug(inspect(&1))
-      iex> Subscriber.start_link()
-      # you can also inject your session, key_expr and callback from outside
-      iex> Subscriber.start_link(%{session: your_session, key_expr: "your_key/expression/**", callback: &IO.inspect/1})
-
-  ### Subscribed?
-
-      iex> alias Zenohex.Examples.Publisher
-      iex> Publisher.start_link()
-      iex> Publisher.put("subscribed?")
-      :ok
-      
-      11:51:53.959 [debug] %Zenohex.Sample{key_expr: "zenohex/examples/pub", value: "subscribed?", kind: :put, reference: #Reference<0.1373489635.746717252.118288>}
-  """
+  @moduledoc false
 
   use Supervisor
 
@@ -40,9 +7,7 @@ defmodule Zenohex.Examples.Subscriber do
 
   alias Zenohex.Examples.Subscriber
 
-  @doc """
-  Start Subscriber.
-  """
+  @doc "Start Subscriber."
   def start_link(args \\ %{}) when is_map(args) do
     session = Map.get(args, :session) || Zenohex.open!()
     key_expr = Map.get(args, :key_expr, "zenohex/examples/**")

--- a/mix.exs
+++ b/mix.exs
@@ -87,7 +87,6 @@ defmodule Zenohex.MixProject do
         ],
         Examples: [
           Zenohex.Examples.Session,
-          Zenohex.Examples.Queryable,
           Zenohex.Examples.Storage
         ]
       ]

--- a/mix.exs
+++ b/mix.exs
@@ -86,7 +86,6 @@ defmodule Zenohex.MixProject do
           Zenohex.Subscriber.Options
         ],
         Examples: [
-          Zenohex.Examples.PullSubscriber,
           Zenohex.Examples.Session,
           Zenohex.Examples.Queryable,
           Zenohex.Examples.Storage

--- a/mix.exs
+++ b/mix.exs
@@ -86,7 +86,6 @@ defmodule Zenohex.MixProject do
           Zenohex.Subscriber.Options
         ],
         Examples: [
-          Zenohex.Examples.Storage
         ]
       ]
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -86,7 +86,6 @@ defmodule Zenohex.MixProject do
           Zenohex.Subscriber.Options
         ],
         Examples: [
-          Zenohex.Examples.Session,
           Zenohex.Examples.Storage
         ]
       ]

--- a/mix.exs
+++ b/mix.exs
@@ -54,7 +54,9 @@ defmodule Zenohex.MixProject do
     [
       name: "zenohex",
       files: [
-        "lib",
+        "lib/zenohex.ex",
+        "lib/zenohex/config",
+        "lib/zenohex/*.ex",
         "native/zenohex_nif/.cargo",
         "native/zenohex_nif/src",
         "native/zenohex_nif/Cargo*",

--- a/mix.exs
+++ b/mix.exs
@@ -86,7 +86,6 @@ defmodule Zenohex.MixProject do
           Zenohex.Subscriber.Options
         ],
         Examples: [
-          Zenohex.Examples.Publisher,
           Zenohex.Examples.Subscriber,
           Zenohex.Examples.PullSubscriber,
           Zenohex.Examples.Session,

--- a/mix.exs
+++ b/mix.exs
@@ -86,7 +86,6 @@ defmodule Zenohex.MixProject do
           Zenohex.Subscriber.Options
         ],
         Examples: [
-          Zenohex.Examples.Subscriber,
           Zenohex.Examples.PullSubscriber,
           Zenohex.Examples.Session,
           Zenohex.Examples.Queryable,

--- a/mix.exs
+++ b/mix.exs
@@ -84,8 +84,6 @@ defmodule Zenohex.MixProject do
           Zenohex.Query.Options,
           Zenohex.Queryable.Options,
           Zenohex.Subscriber.Options
-        ],
-        Examples: [
         ]
       ]
     ]


### PR DESCRIPTION
Github 上での表示は以下リンク先のようになります。

https://github.com/b5g-ex/zenohex/blob/pojiro/update-examples-docs/lib/zenohex/examples/README.md