### PR TITLE
Ignore Rust related library file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ zenohex-*.tar
 # Ignore compiled NIF for Rustler
 /priv/native/*zenohex_nif*
 
+# Ignore Rust related library file
+/priv/native/rustls_platform_verifier.so
+
 # Ignore local Dialyzer PLTs
 /priv/plts/*.plt
 /priv/plts/*.plt.hash


### PR DESCRIPTION
I'm not sure whether this is due to Zenoh or Rustler bumps, but from v0.5.1, a file named `priv/native/rustls_platform_verifier.so` is generated.

```
% rm -rf _build && mix compile
<skip>
==> rustler_precompiled
Compiling 4 files (.ex)
Generated rustler_precompiled app
==> zenohex
Compiling 22 files (.ex)
Compiling crate zenohex_nif in release mode (native/zenohex_nif)
Copying /<ws_dir>/zenohex/native/zenohex_nif/target/release/deps/librustls_platform_verifier-7a7678b64ab91b26.dylib to priv/native/rustls_platform_verifier.so
Copying /<ws_dir>/zenohex/native/zenohex_nif/target/release/libzenohex_nif.dylib to priv/native/zenohex_nif.so
Generated zenohex app
```

In any case, I think this file should be added to the .gitignore since it's a generated library file.

@pojiro Could you let me know whether this file is generated in your Linux environment as well?
Also, even if it only occurs in my macOS environment, is this change acceptable?