### PR TITLE
Fix recv_deadline dropping replies before channel disconnect

### DIFF
--- a/native/zenohex_nif/src/lib.rs
+++ b/native/zenohex_nif/src/lib.rs
@@ -36,6 +36,7 @@ mod atoms {
         priority,
         query_timeout,
         target,
+        timeout,
         timestamp,
         zenohex_nif = "Elixir.Zenohex.Nif",
     }

--- a/native/zenohex_nif/src/session.rs
+++ b/native/zenohex_nif/src/session.rs
@@ -342,13 +342,24 @@ fn session_get<'a>(
     loop {
         // NOTE: `recv_deadline` document says following,
         //       > If the deadline has expired, this will return None.
-        let option_reply = channel_handler
-            .recv_deadline(deadline)
-            .map_err(|error| rustler::Error::Term(crate::zenoh_error!(error)))?;
-
-        let Some(reply) = option_reply else {
-            // the deadline has expired
-            return Err(rustler::Error::Term(Box::new("timeout")));
+        let reply = match channel_handler.recv_deadline(deadline) {
+            Ok(Some(reply)) => reply,
+            Ok(None) => {
+                // If we timeout but have collected replies, return them successfully.
+                // Only error on timeout if we have no data at all.
+                if !replies.is_empty() {
+                    break;
+                }
+                return Err(rustler::Error::Term(Box::new(crate::atoms::timeout())));
+            }
+            Err(error) => {
+                // If the channel disconnected after receiving some replies,
+                // treat it as a successful completion and return what we collected.
+                if channel_handler.is_disconnected() && !replies.is_empty() {
+                    break;
+                }
+                return Err(rustler::Error::Term(crate::zenoh_error!(error)));
+            }
         };
 
         let term = match reply.result() {
@@ -359,10 +370,6 @@ fn session_get<'a>(
         };
 
         replies.push(term);
-
-        if channel_handler.is_empty() {
-            break;
-        }
     }
 
     Ok((rustler::types::atom::ok(), replies))

--- a/test/zenohex_test.exs
+++ b/test/zenohex_test.exs
@@ -82,13 +82,6 @@ defmodule ZenohexTestModeCommon do
         :ok = Zenohex.Queryable.undeclare(queryable_id)
       end
 
-      # WHY:  :skip, because this test is flaky.
-      #       Sometimes `get` receives only a ReplyError.
-      # FIXME: This test is flaky, so it is currently skipped.
-      #        We have already reported the possibly related behavior in the following issue.
-      #        https://github.com/eclipse-zenoh/zenoh/issues/2048
-      #        Once we receive a reply, revisit this.
-      @tag :skip
       test "get/reply with ReplyError", %{session_id: session_id} do
         {:ok, queryable_id} = Zenohex.Session.declare_queryable(session_id, "key/expr", self())
 


### PR DESCRIPTION
This PR is intended to fix the unstable behavior of session_get, which has been observed as a flaky test.
This behaviour is caused from following `break`. 

```rust
    loop {
        ...
        if channel_handler.is_empty() {
            break;
        }
    }
```

Since the `channel_handler` may temporarily become empty during reception and then receive data again, it should not `break` until it gets `disconnected`.