### PR TITLE
Bump Zenoh to v1.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This allows the creation and communication of a large number of fault-tolerant n
 
 ## Usage
 
-**Currently, Zenohex uses version 1.6.1 of Zenoh.**
+**Currently, Zenohex uses version 1.6.2 of Zenoh.**
 
 We recommend you use the same version to communicate with other Zenoh clients or routers since version compatibility is somewhat important for Zenoh.
 Please also check the description on [Releases](https://github.com/biyooon-ex/zenohex/releases) about the corresponding Zenoh version.

--- a/native/zenohex_nif/Cargo.lock
+++ b/native/zenohex_nif/Cargo.lock
@@ -3487,14 +3487,15 @@ dependencies = [
 
 [[package]]
 name = "zenoh"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7571f5aa2abe806de6e6c920132ce21ef64a5db39e4ed983e651b96f6676d3a"
+checksum = "c5df040795169d4b6e4fc8a5f9dce81b5210d1d606399634ec380deda30c347f"
 dependencies = [
  "ahash",
  "arc-swap",
  "async-trait",
  "bytes",
+ "const_format",
  "flume",
  "futures",
  "git-version",
@@ -3538,18 +3539,18 @@ dependencies = [
 
 [[package]]
 name = "zenoh-buffers"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fffa8d9cd0aad93ecf2dfa4c23aecaf2e6c92b416051af883fdd1302c2f24a7c"
+checksum = "510921897b03793f399b7eaec176355a12293afa1e791c3f844ef12fa08aecc4"
 dependencies = [
  "zenoh-collections",
 ]
 
 [[package]]
 name = "zenoh-codec"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d714d46d6afd3fa9631e22d5c25d734b3029b598a5244803bdeab242a51680c1"
+checksum = "585a77eff7a781726aeeafab52ad175be0dcfc92376a756c23a51f6701a73ba0"
 dependencies = [
  "tracing",
  "uhlc",
@@ -3559,18 +3560,18 @@ dependencies = [
 
 [[package]]
 name = "zenoh-collections"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cb8319ddce6ec037ecece551e9211d3f7435e2c7246c9ac2e9812e0fce6408"
+checksum = "fa17a7ecf321aba18eabf99a37390b7a6524e826b6f8cb38f9361479ece28887"
 dependencies = [
  "ahash",
 ]
 
 [[package]]
 name = "zenoh-config"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d596de324c9eb813472b05a94301c1fb8c0967f74889f554b2875b2a280aef17"
+checksum = "c02801ef8fd8d0b10437055dac10fd961fdc3a6356439dd52ee627e7f31b9295"
 dependencies = [
  "json5",
  "nonempty-collections",
@@ -3593,9 +3594,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-core"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16c3f301b3818095279d807ab127cae8182032b062c0cfab92b870a6fcc2c550"
+checksum = "325645d09d0f74f48051b51c2ab73e270c16d9d7d408c41eb47ed8f067451cd9"
 dependencies = [
  "lazy_static",
  "tokio",
@@ -3605,9 +3606,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-crypto"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a72f5874ef1a412b17bc23f3178bbbf096448421d73a87fe0d32e1c4b74893a"
+checksum = "5244d615594f1c2149cba6177f15e76cc825e2839230e26693f2b723367b6c2f"
 dependencies = [
  "aes",
  "hmac",
@@ -3619,9 +3620,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-keyexpr"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33674ca3f009879a819ce1ad720e1de2b15ec902b038044c5213e6a95d85782d"
+checksum = "c9495c0ca85331f87442b465760a7fb7334370354742a4201b719cc2533afee7"
 dependencies = [
  "getrandom 0.2.12",
  "hashbrown 0.16.0",
@@ -3635,9 +3636,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf9c72139afb725809468f5d741120fd9a639050ed81c9c83f01b9dc48706c3"
+checksum = "001a7f07522b06ae6364ae787ab83eddf4e43f56f7f138fe3e54ea123ee3523b"
 dependencies = [
  "zenoh-config",
  "zenoh-link-commons",
@@ -3654,9 +3655,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-commons"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c86f819aff18ed0a8a1be188fbccd9c7cc06985c3c8ee0756158f674c05ba046"
+checksum = "5be05b499b789afb2024de4253e12ccaa3e296f66a0db6147deb9acec491f622"
 dependencies = [
  "async-trait",
  "base64",
@@ -3688,9 +3689,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-quic"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31cf6ee83bc895a6ef42f1fc049bbe88f766af00c57b46828f5055a9174d87ce"
+checksum = "4168034bb7005d313ba834d105ede7c7f9fac48684f80a140fccb8302e9ca4aa"
 dependencies = [
  "async-trait",
  "base64",
@@ -3714,9 +3715,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-quic_datagram"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5971612d550adb5beb6c9552d50c4939dc2d765f3e4661e1da947266f2361af"
+checksum = "b954594b5283afcbfc65a5090829b7a09701a29c99ad528fc09cdcef607a4e51"
 dependencies = [
  "async-trait",
  "quinn",
@@ -3735,9 +3736,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-tcp"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dafdac1d54977eebe0d88b0942042da55d351d8a0585016985b8653d9dd3cf8"
+checksum = "3b968d3506682350760fb69c07b3c9aea07f351ac39993c7d948bdc5a19d5645"
 dependencies = [
  "async-trait",
  "socket2 0.5.9",
@@ -3753,9 +3754,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-tls"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14a9f445915860a65814f5df43eb862f9efb5cb48806e2057e6606d0079d0c49"
+checksum = "a810a4ba44011cc4c75713eadcf1a03fb2e22f0907d62f9b12c04d42ba1d596f"
 dependencies = [
  "async-trait",
  "base64",
@@ -3783,9 +3784,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-udp"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7b40b2bcd7a7960b1ab2c5ba757b0c0f57a095d3575e8ee92b655f2bcdfda0d"
+checksum = "a4178b940cc613b4d0db3f06ceb71377199cacb22087f589bc60d1b4df6a2365"
 dependencies = [
  "async-trait",
  "libc",
@@ -3805,9 +3806,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-unixsock_stream"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ba317143219272c1523ef3032186943b44f083ad9cb19f388a6e32f24fae87"
+checksum = "486de15a9f4ecc6d5839ec0153450bafee202355ea20810e81c65d70045d210b"
 dependencies = [
  "async-trait",
  "nix",
@@ -3824,9 +3825,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-link-ws"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd43aa2140b38125dd5ed59fdcc7e671e5313c636356ac4ea9ac46fa85d64b41"
+checksum = "1cb73dab1b8b8406ac288586727590e6830cc35a25f3c31ffb3d88518446f7e9"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -3845,9 +3846,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-macros"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eb6590a03189f41b08dea8362569b7ef979bb45dbaa377207f91bca28f2934a"
+checksum = "2bbff17ef687e10ed4f6a956fb78fc97205a4a6242c657638e8e5da726840aca"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3857,9 +3858,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-plugin-trait"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e551d84ccd2426762479a6ec779dc24b2b9d3d8cdcca5555aa37b697bdc80169"
+checksum = "968571b0b585c5be1f19c553b368994424a869af46a4785bf5a3248194a97172"
 dependencies = [
  "git-version",
  "libloading",
@@ -3875,9 +3876,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-protocol"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0af0b7bacb807c58ae17e76fb61890b52a4f244487d74d94b7382f130e34e5b2"
+checksum = "879a66ef51831f54f5f824bf9005bf73129bc2485053311ffb7a245f907f721c"
 dependencies = [
  "const_format",
  "rand 0.8.5",
@@ -3890,18 +3891,18 @@ dependencies = [
 
 [[package]]
 name = "zenoh-result"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ea6c081e1d5827d1583d602c3e514fab4bfeb07efca446004c62f7426142e9"
+checksum = "e0f564d3324e443d0d48a4656d89bab1d0b263660fb7e17ba149c464e62f94bd"
 dependencies = [
  "anyhow",
 ]
 
 [[package]]
 name = "zenoh-runtime"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab11ac3b641cec8d7e70a08ea2b0af5b180891dcc61724d9c7ab948c1241a06f"
+checksum = "e3a5cef13fd469aeb146518532751dbecd2b0f99ac56b6df667f954f11348dcf"
 dependencies = [
  "lazy_static",
  "ron",
@@ -3914,9 +3915,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-sync"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "586b4368ce7ff8cd789408f46151e337a8af3619536ef2385ee58e5d93acf8d8"
+checksum = "04a23123511fb7ce5990a778dcdcf41b5129ad8c5ef8d1e7ff719a538c3270e3"
 dependencies = [
  "arc-swap",
  "event-listener",
@@ -3929,9 +3930,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-task"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15791f65659a22ba1a046d4de96bfb228f937cac2dc23bf591f1725c68aa4d44"
+checksum = "8ad997618409140b23a2ef0957f7995afec2667ff3951f580de8a506c7814e41"
 dependencies = [
  "futures",
  "tokio",
@@ -3943,9 +3944,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-transport"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca95916cd3defba400443ca158c5a940353ffef486948a396699cd404360a7ca"
+checksum = "2abd4521cd556093161156fc0799a506743304e1510fc7ed83adff99ca601f34"
 dependencies = [
  "async-trait",
  "crossbeam-utils",
@@ -3978,9 +3979,9 @@ dependencies = [
 
 [[package]]
 name = "zenoh-util"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bee14716ac8d2ce4b6c700b1c2de63bdd2dad4de957b3ea43bf91ea7d607a18"
+checksum = "42a736159ed0935c9ef258c151067ccce40f95f08d7f9360993e858e268b0a9d"
 dependencies = [
  "async-trait",
  "const_format",

--- a/native/zenohex_nif/Cargo.toml
+++ b/native/zenohex_nif/Cargo.toml
@@ -21,6 +21,6 @@ rustler = { version = "=0.37.0", features = ["nif_version_2_15"] }
 # features
 #   zenoh::session::EntityGlobalId needs "unstable"
 #   "plugins" needs "unstable" and "internal"
-zenoh = { version = "=1.6.1", features = ["unstable", "internal", "plugins"] }
+zenoh = { version = "=1.6.2", features = ["unstable", "internal", "plugins"] }
 
 log = { version = "0.4", features = ["std"] }


### PR DESCRIPTION
https://github.com/eclipse-zenoh/zenoh/releases/tag/1.6.2