### PR TITLE
Release v0.6.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ You can install this package into your project by adding `zenohex` to your list 
   defp deps do
     [
       ...
-      {:zenohex, "~> 0.6.1"},
+      {:zenohex, "~> 0.6.2"},
       ...
     ]
   end
@@ -130,7 +130,7 @@ When you want to build NIF module locally into your project, install Rustler by 
   defp deps do
     [
       ...
-      {:zenohex, "~> 0.6.1"},
+      {:zenohex, "~> 0.6.2"},
       {:rustler, ">= 0.0.0", optional: true},
       ...
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Zenohex.MixProject do
   use Mix.Project
 
-  @version "0.6.1"
+  @version "0.6.2"
   @source_url "https://github.com/biyooon-ex/zenohex"
 
   def project do

--- a/native/zenohex_nif/Cargo.lock
+++ b/native/zenohex_nif/Cargo.lock
@@ -4006,7 +4006,7 @@ dependencies = [
 
 [[package]]
 name = "zenohex_nif"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "log",
  "rustler",

--- a/native/zenohex_nif/Cargo.toml
+++ b/native/zenohex_nif/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zenohex_nif"
-version = "0.6.1"
+version = "0.6.2"
 authors = []
 edition = "2021"
 


### PR DESCRIPTION
**Currently, Zenohex uses version 1.6.2 of Zenoh.**