### PR TITLE
Release v0.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ FYI, the development team currently uses the following versions.
 
 - Elixir 1.18.4-otp-27
 - Erlang/OTP 27.3.4.2
-- Rust 1.85.0
+- Rust 1.93.0
 
 ### Installation
 
@@ -50,7 +50,7 @@ You can install this package into your project by adding `zenohex` to your list 
   defp deps do
     [
       ...
-      {:zenohex, "~> 0.7.2"},
+      {:zenohex, "~> 0.8.0"},
       ...
     ]
   end
@@ -130,7 +130,7 @@ When you want to build NIF module locally into your project, install Rustler by 
   defp deps do
     [
       ...
-      {:zenohex, "~> 0.7.2"},
+      {:zenohex, "~> 0.8.0"},
       {:rustler, ">= 0.0.0", optional: true},
       ...
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Zenohex.MixProject do
   use Mix.Project
 
-  @version "0.7.2"
+  @version "0.8.0"
   @source_url "https://github.com/biyooon-ex/zenohex"
 
   def project do

--- a/native/zenohex_nif/Cargo.lock
+++ b/native/zenohex_nif/Cargo.lock
@@ -4073,7 +4073,7 @@ dependencies = [
 
 [[package]]
 name = "zenohex_nif"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "log",
  "rustler",

--- a/native/zenohex_nif/Cargo.toml
+++ b/native/zenohex_nif/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zenohex_nif"
-version = "0.7.2"
+version = "0.8.0"
 authors = []
 edition = "2021"
 


### PR DESCRIPTION
Currently, Zenohex uses version 1.8.0 of Zenoh.