### PR TITLE
Drop support for Elixir 1.13 and 1.14.

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Zenohex.MixProject do
     [
       app: :zenohex,
       version: @version,
-      elixir: "~> 1.13",
+      elixir: "~> 1.15",
       description: "Zenoh client library for elixir.",
       package: package(),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Since the core team has no specific reason to continue supporting older versions, we will follow the changes in Rustler. 
Ref: https://github.com/biyooon-ex/zenohex/pull/167#issuecomment-4140828014