### PR TITLE
Add querier and stable opts

### DIFF
--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -53,7 +53,7 @@ jobs:
           cargo fmt --all -- --check
 
       - name: mix credo
-        run: mix credo --ignore fixme
+        run: mix credo
 
       - name: Cache PLTs
         id: plts-cache

--- a/lib/zenohex/examples/liveliness_subscriber.ex
+++ b/lib/zenohex/examples/liveliness_subscriber.ex
@@ -31,6 +31,7 @@ defmodule Zenohex.Examples.LivelinessSubscriber do
   @spec start_link([
           {:session_id, Zenohex.Session.id()}
           | {:key_expr, String.t()}
+          | {:name, GenServer.name()}
           | {:callback, (Zenohex.Sample.t() -> term())}
         ]) :: GenServer.on_start()
   def start_link(args) do
@@ -41,7 +42,7 @@ defmodule Zenohex.Examples.LivelinessSubscriber do
   @doc """
   Stops #{__MODULE__}
   """
-  @spec stop(module()) :: :ok
+  @spec stop(GenServer.server()) :: :ok
   def stop(name \\ __MODULE__) do
     GenServer.call(name, :stop)
   end

--- a/lib/zenohex/examples/liveliness_subscriber.ex
+++ b/lib/zenohex/examples/liveliness_subscriber.ex
@@ -42,7 +42,7 @@ defmodule Zenohex.Examples.LivelinessSubscriber do
   @doc """
   Stops #{__MODULE__}
   """
-  @spec stop(GenServer.server()) :: :ok
+  @spec stop(GenServer.server()) :: :ok | {:error, reason :: term()}
   def stop(name \\ __MODULE__) do
     GenServer.call(name, :stop)
   end

--- a/lib/zenohex/examples/publisher.ex
+++ b/lib/zenohex/examples/publisher.ex
@@ -19,7 +19,7 @@ defmodule Zenohex.Examples.Publisher do
   @doc """
   Sends a `Zenohex.Sample` with `kind: :put` and the given payload.
   """
-  @spec put(module(), binary()) :: :ok | {:error, reason :: term()}
+  @spec put(GenServer.server(), binary()) :: :ok | {:error, reason :: term()}
   def put(name \\ __MODULE__, payload) do
     GenServer.call(name, {:put, payload})
   end
@@ -27,7 +27,7 @@ defmodule Zenohex.Examples.Publisher do
   @doc """
   Sends a `Zenohex.Sample` with `kind: :delete`.
   """
-  @spec delete(module()) :: :ok | {:error, reason :: term()}
+  @spec delete(GenServer.server()) :: :ok | {:error, reason :: term()}
   def delete(name \\ __MODULE__) do
     GenServer.call(name, :delete)
   end
@@ -44,6 +44,7 @@ defmodule Zenohex.Examples.Publisher do
   @spec start_link([
           {:session_id, Zenohex.Session.id()}
           | {:key_expr, String.t()}
+          | {:name, GenServer.name()}
         ]) :: GenServer.on_start()
   def start_link(args) do
     name = Keyword.get(args, :name, __MODULE__)
@@ -53,7 +54,7 @@ defmodule Zenohex.Examples.Publisher do
   @doc """
   Stops #{__MODULE__}
   """
-  @spec stop(module()) :: :ok
+  @spec stop(GenServer.server()) :: :ok
 
   def stop(name \\ __MODULE__) do
     GenServer.call(name, :stop)

--- a/lib/zenohex/examples/publisher.ex
+++ b/lib/zenohex/examples/publisher.ex
@@ -54,8 +54,7 @@ defmodule Zenohex.Examples.Publisher do
   @doc """
   Stops #{__MODULE__}
   """
-  @spec stop(GenServer.server()) :: :ok
-
+  @spec stop(GenServer.server()) :: :ok | {:error, reason :: term()}
   def stop(name \\ __MODULE__) do
     GenServer.call(name, :stop)
   end

--- a/lib/zenohex/examples/querier.ex
+++ b/lib/zenohex/examples/querier.ex
@@ -73,6 +73,7 @@ defmodule Zenohex.Examples.Querier do
   @spec start_link([
           {:session_id, Zenohex.Session.id()}
           | {:key_expr, String.t()}
+          | {:name, GenServer.name()}
           | {:querier_opts, Zenohex.Session.querier_opts()}
         ]) :: GenServer.on_start()
   def start_link(args) do
@@ -83,7 +84,7 @@ defmodule Zenohex.Examples.Querier do
   @doc """
   Stops #{__MODULE__}
   """
-  @spec stop(module()) :: :ok | {:error, reason :: term()}
+  @spec stop(GenServer.server()) :: :ok | {:error, reason :: term()}
   def stop(name \\ __MODULE__) do
     GenServer.call(name, :stop)
   end

--- a/lib/zenohex/examples/querier.ex
+++ b/lib/zenohex/examples/querier.ex
@@ -1,0 +1,123 @@
+defmodule Zenohex.Examples.Querier do
+  @moduledoc """
+  Example `GenServer` implementation of `Querier`
+  using `Zenohex.Session.declare_querier/3`.
+
+  This example demonstrates how to reuse a declared querier for multiple queries.
+
+  For the actual implementation, please refer to the following,
+
+  - #{Zenohex.MixProject.project()[:source_url]}/tree/main/#{Path.relative_to_cwd(__ENV__.file)}
+
+  ## Examples
+
+  Assumes a matching queryable is already running and replies on `key/expr/**`.
+
+      iex> {:ok, session_id} = Zenohex.Session.open()
+      iex> {:ok, _querier_pid} =
+      ...>   Zenohex.Examples.Querier.start_link(
+      ...>     session_id: session_id,
+      ...>     key_expr: "key/expr/**"
+      ...>   )
+      iex> Zenohex.Examples.Querier.get(timeout: 1_000)
+      {:ok, [%Zenohex.Sample{key_expr: "key/expr/1", payload: "reply"}]}
+  """
+
+  use GenServer
+
+  @default_timeout 1_000
+
+  @type get_opts :: [
+          timeout: non_neg_integer(),
+          attachment: binary() | nil,
+          encoding: String.t(),
+          parameters: String.t(),
+          payload: binary() | nil
+        ]
+
+  @doc """
+  Executes a query with the declared querier.
+
+  The timeout used here controls how long the Elixir side waits while collecting
+  replies. To configure the network-side query timeout, pass `query_timeout:` in
+  `:querier_opts` when starting the server.
+  """
+  @spec get(get_opts()) ::
+          {:ok, [Zenohex.Sample.t() | Zenohex.Query.ReplyError.t()]}
+          | {:error, :timeout}
+          | {:error, reason :: term()}
+  def get(opts) when is_list(opts) do
+    get(__MODULE__, opts)
+  end
+
+  @spec get(GenServer.server(), get_opts()) ::
+          {:ok, [Zenohex.Sample.t() | Zenohex.Query.ReplyError.t()]}
+          | {:error, :timeout}
+          | {:error, reason :: term()}
+  def get(name, opts \\ []) do
+    querier_id = GenServer.call(name, :id)
+    {timeout, querier_opts} = Keyword.pop(opts, :timeout, @default_timeout)
+    Zenohex.Querier.get(querier_id, timeout, querier_opts)
+  end
+
+  @doc """
+  Starts #{__MODULE__}.
+
+  ## Parameters
+
+    - `args` – a keyword list that can include the following keys:
+      - `:session_id` – the ID of the session
+      - `:key_expr` – the key expression to query
+      - `:querier_opts` – options passed to `Zenohex.Session.declare_querier/3`
+  """
+  @spec start_link([
+          {:session_id, Zenohex.Session.id()}
+          | {:key_expr, String.t()}
+          | {:querier_opts, Zenohex.Session.querier_opts()}
+        ]) :: GenServer.on_start()
+  def start_link(args) do
+    name = Keyword.get(args, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, args, name: name)
+  end
+
+  @doc """
+  Stops #{__MODULE__}
+  """
+  @spec stop(module()) :: :ok | {:error, reason :: term()}
+  def stop(name \\ __MODULE__) do
+    GenServer.call(name, :stop)
+  end
+
+  @doc false
+  def child_spec(init_arg), do: super(init_arg)
+
+  @doc false
+  def init(args) do
+    session_id =
+      Keyword.get_lazy(args, :session_id, fn ->
+        {:ok, session_id} = Zenohex.Session.open()
+        session_id
+      end)
+
+    key_expr = Keyword.get(args, :key_expr, "key/expr/**")
+    querier_opts = Keyword.get(args, :querier_opts, [])
+
+    {:ok, querier_id} = Zenohex.Session.declare_querier(session_id, key_expr, querier_opts)
+
+    {:ok,
+     %{
+       querier_id: querier_id
+     }}
+  end
+
+  def handle_call(:id, _from, state) do
+    {:reply, state.querier_id, state}
+  end
+
+  def handle_call(:stop, _from, state) do
+    reply = Zenohex.Querier.undeclare(state.querier_id)
+    reason = :normal
+
+    {:stop, reason, reply, state}
+  end
+end

--- a/lib/zenohex/examples/queryable.ex
+++ b/lib/zenohex/examples/queryable.ex
@@ -43,7 +43,7 @@ defmodule Zenohex.Examples.Queryable do
   @doc """
   Stops #{__MODULE__}
   """
-  @spec stop(GenServer.server()) :: :ok
+  @spec stop(GenServer.server()) :: :ok | {:error, reason :: term()}
   def stop(name \\ __MODULE__) do
     GenServer.call(name, :stop)
   end

--- a/lib/zenohex/examples/queryable.ex
+++ b/lib/zenohex/examples/queryable.ex
@@ -32,6 +32,7 @@ defmodule Zenohex.Examples.Queryable do
   @spec start_link([
           {:session_id, Zenohex.Session.id()}
           | {:key_expr, String.t()}
+          | {:name, GenServer.name()}
           | {:callback, (Zenohex.Query.t() -> term())}
         ]) :: GenServer.on_start()
   def start_link(args) do
@@ -42,7 +43,7 @@ defmodule Zenohex.Examples.Queryable do
   @doc """
   Stops #{__MODULE__}
   """
-  @spec stop(module()) :: :ok
+  @spec stop(GenServer.server()) :: :ok
   def stop(name \\ __MODULE__) do
     GenServer.call(name, :stop)
   end

--- a/lib/zenohex/examples/scout.ex
+++ b/lib/zenohex/examples/scout.ex
@@ -31,6 +31,7 @@ defmodule Zenohex.Examples.Scout do
   @spec start_link([
           {:what, Zenohex.Scouting.what()}
           | {:config, Zenohex.Config.t()}
+          | {:name, GenServer.name()}
           | {:callback, (Zenohex.Scouting.Hello.t() -> term())}
         ]) :: GenServer.on_start()
   def start_link(args) do
@@ -41,6 +42,7 @@ defmodule Zenohex.Examples.Scout do
   @doc """
   Stops #{__MODULE__}
   """
+  @spec stop(GenServer.server()) :: :ok
   def stop(name \\ __MODULE__) do
     GenServer.call(name, :stop)
   end

--- a/lib/zenohex/examples/scout.ex
+++ b/lib/zenohex/examples/scout.ex
@@ -42,7 +42,7 @@ defmodule Zenohex.Examples.Scout do
   @doc """
   Stops #{__MODULE__}
   """
-  @spec stop(GenServer.server()) :: :ok
+  @spec stop(GenServer.server()) :: :ok | {:error, reason :: term()}
   def stop(name \\ __MODULE__) do
     GenServer.call(name, :stop)
   end

--- a/lib/zenohex/examples/subscriber.ex
+++ b/lib/zenohex/examples/subscriber.ex
@@ -31,6 +31,7 @@ defmodule Zenohex.Examples.Subscriber do
   @spec start_link([
           {:session_id, Zenohex.Session.id()}
           | {:key_expr, String.t()}
+          | {:name, GenServer.name()}
           | {:callback, (Zenohex.Sample.t() -> term())}
         ]) :: GenServer.on_start()
   def start_link(args) do
@@ -41,7 +42,7 @@ defmodule Zenohex.Examples.Subscriber do
   @doc """
   Stops #{__MODULE__}
   """
-  @spec stop(module()) :: :ok
+  @spec stop(GenServer.server()) :: :ok
   def stop(name \\ __MODULE__) do
     GenServer.call(name, :stop)
   end

--- a/lib/zenohex/examples/subscriber.ex
+++ b/lib/zenohex/examples/subscriber.ex
@@ -42,7 +42,7 @@ defmodule Zenohex.Examples.Subscriber do
   @doc """
   Stops #{__MODULE__}
   """
-  @spec stop(GenServer.server()) :: :ok
+  @spec stop(GenServer.server()) :: :ok | {:error, reason :: term()}
   def stop(name \\ __MODULE__) do
     GenServer.call(name, :stop)
   end

--- a/lib/zenohex/liveliness.ex
+++ b/lib/zenohex/liveliness.ex
@@ -12,6 +12,10 @@ defmodule Zenohex.Liveliness do
           query_timeout: non_neg_integer()
         ]
 
+  @type declare_subscriber_opts :: [
+          history: boolean()
+        ]
+
   @doc """
   Query liveliness tokens with matching key expressions.
 
@@ -38,15 +42,16 @@ defmodule Zenohex.Liveliness do
     - `session_id` — The session to declare on
     - `key_expr` — Key expression to associate with
     - `pid` - Process to receive liveliness updates (defaults to `self()`)
+    - `opts` - Options for configuring the liveliness subscriber.
 
   ## Examples
 
       iex> Zenohex.Liveliness.declare_subscriber(session_id, "key/expr")
       {:ok, #Reference<...>}
   """
-  @spec declare_subscriber(Zenohex.Session.id(), String.t(), pid()) ::
+  @spec declare_subscriber(Zenohex.Session.id(), String.t(), pid(), declare_subscriber_opts()) ::
           {:ok, subscriber_id :: Zenohex.Subscriber.id()} | {:error, reason :: term()}
-  defdelegate declare_subscriber(session_id, key_expr, pid \\ self()),
+  defdelegate declare_subscriber(session_id, key_expr, pid \\ self(), opts \\ []),
     to: Zenohex.Nif,
     as: :liveliness_declare_subscriber
 

--- a/lib/zenohex/matching.ex
+++ b/lib/zenohex/matching.ex
@@ -27,7 +27,7 @@ defmodule Zenohex.Matching do
   @doc """
   Declares a matching listener for a publisher or querier.
 
-  Status updates are delivered to `pid` as `%Zenohex.Matching.Status{}` messages.
+  Status updates are delivered to `pid` as `t:Zenohex.Matching.Status.t/0` messages.
 
   > ### Important {: .info}
   >

--- a/lib/zenohex/matching.ex
+++ b/lib/zenohex/matching.ex
@@ -1,0 +1,50 @@
+defmodule Zenohex.Matching do
+  @moduledoc """
+  Interface for querying current matching status and listening for status changes
+  for publishers and queriers.
+
+  Matching is supported for publisher and querier entities.
+  """
+
+  @type entity_id :: Zenohex.Publisher.id() | Zenohex.Querier.id()
+  @type listener_id :: reference()
+
+  defmodule Status do
+    @moduledoc """
+    Matching status for a publisher or querier.
+    """
+
+    @type t :: %__MODULE__{matching: boolean()}
+    defstruct matching: false
+  end
+
+  @doc """
+  Returns the current matching status for a publisher or querier.
+  """
+  @spec status(entity_id()) :: {:ok, boolean()} | {:error, reason :: term()}
+  defdelegate status(entity_id), to: Zenohex.Nif, as: :matching_status
+
+  @doc """
+  Declares a matching listener for a publisher or querier.
+
+  Status updates are delivered to `pid` as `%Zenohex.Matching.Status{}` messages.
+
+  > ### Important {: .info}
+  >
+  > The returned `listener_id` must be held for as long as the listener is in use.
+  > If it is not held and gets garbage-collected by the BEAM,
+  > the underlying listener in Rust will be automatically dropped.
+  """
+  @spec declare_listener(entity_id(), pid()) :: {:ok, listener_id()} | {:error, reason :: term()}
+  defdelegate declare_listener(entity_id, pid \\ self()),
+    to: Zenohex.Nif,
+    as: :matching_declare_listener
+
+  @doc """
+  Undeclares the matching listener identified by the given ID.
+  """
+  @spec undeclare_listener(listener_id()) :: :ok | {:error, reason :: term()}
+  defdelegate undeclare_listener(listener_id),
+    to: Zenohex.Nif,
+    as: :matching_undeclare_listener
+end

--- a/lib/zenohex/nif.ex
+++ b/lib/zenohex/nif.ex
@@ -3,6 +3,7 @@ defmodule Zenohex.Nif do
 
   @type session_id :: reference()
   @type entity_id :: reference()
+  @type matching_listener :: reference()
   @type query :: reference()
   @type scout :: reference()
   @type liveliness_token :: reference()
@@ -101,6 +102,19 @@ defmodule Zenohex.Nif do
 
   @spec querier_undeclare(entity_id()) :: :ok | {:error, reason :: term()}
   def querier_undeclare(_querier_id), do: err()
+
+  # Matching
+
+  @spec matching_status(entity_id()) ::
+          {:ok, boolean()} | {:error, reason :: term()}
+  def matching_status(_entity_id), do: err()
+
+  @spec matching_declare_listener(entity_id(), pid()) ::
+          {:ok, matching_listener()} | {:error, reason :: term()}
+  def matching_declare_listener(_entity_id, _pid), do: err()
+
+  @spec matching_undeclare_listener(matching_listener()) :: :ok | {:error, reason :: term()}
+  def matching_undeclare_listener(_matching_listener), do: err()
 
   # Subscriber
 

--- a/lib/zenohex/nif.ex
+++ b/lib/zenohex/nif.ex
@@ -68,6 +68,10 @@ defmodule Zenohex.Nif do
           {:ok, entity_id()} | {:error, reason :: term()}
   def session_declare_publisher(_session_id, _key_expr, _opts), do: err()
 
+  @spec session_declare_querier(session_id(), String.t(), keyword()) ::
+          {:ok, entity_id()} | {:error, reason :: term()}
+  def session_declare_querier(_session_id, _key_expr, _opts), do: err()
+
   @spec session_declare_subscriber(session_id(), String.t(), pid(), keyword()) ::
           {:ok, entity_id()} | {:error, reason :: term()}
   def session_declare_subscriber(_session_id, _key_expr, _pid, _opts), do: err()
@@ -86,6 +90,17 @@ defmodule Zenohex.Nif do
 
   @spec publisher_delete(entity_id(), keyword()) :: :ok | {:error, reason :: term()}
   def publisher_delete(_publisher_id, _opts), do: err()
+
+  # Querier
+
+  @spec querier_get(entity_id(), non_neg_integer(), keyword()) ::
+          {:ok, [Zenohex.Sample.t() | Zenohex.Query.ReplyError.t()]}
+          | {:error, :timeout}
+          | {:error, reason :: term()}
+  def querier_get(_querier_id, _timeout, _opts), do: err()
+
+  @spec querier_undeclare(entity_id()) :: :ok | {:error, reason :: term()}
+  def querier_undeclare(_querier_id), do: err()
 
   # Subscriber
 

--- a/lib/zenohex/querier.ex
+++ b/lib/zenohex/querier.ex
@@ -19,9 +19,9 @@ defmodule Zenohex.Querier do
   @doc """
   Executes a query using the specified querier.
 
-  The positional `timeout` controls how long the BEAM side waits while collecting
-  replies. Declaration-time `:query_timeout` configured on the querier controls the
-  network-side Zenoh query timeout.
+  The positional `timeout` controls how long this function waits while collecting
+  replies. Declaration-time `:query_timeout` configured on the querier sets the
+  Zenoh query timeout.
   """
   @spec get(id(), non_neg_integer(), get_opts()) ::
           {:ok, [Zenohex.Sample.t() | Zenohex.Query.ReplyError.t()]}

--- a/lib/zenohex/querier.ex
+++ b/lib/zenohex/querier.ex
@@ -1,0 +1,37 @@
+defmodule Zenohex.Querier do
+  @moduledoc """
+  Interface for reusable Zenoh queriers via the native layer.
+
+  Querier IDs are obtained from `Zenohex.Session.declare_querier/3`.
+  A querier can issue multiple `get/3` requests while reusing its declaration-time
+  configuration.
+  """
+
+  @type id :: reference()
+
+  @type get_opts :: [
+          attachment: binary() | nil,
+          encoding: String.t(),
+          parameters: String.t(),
+          payload: binary() | nil
+        ]
+
+  @doc """
+  Executes a query using the specified querier.
+
+  The positional `timeout` controls how long the BEAM side waits while collecting
+  replies. Declaration-time `:query_timeout` configured on the querier controls the
+  network-side Zenoh query timeout.
+  """
+  @spec get(id(), non_neg_integer(), get_opts()) ::
+          {:ok, [Zenohex.Sample.t() | Zenohex.Query.ReplyError.t()]}
+          | {:error, :timeout}
+          | {:error, reason :: term()}
+  defdelegate get(id, timeout, opts \\ []), to: Zenohex.Nif, as: :querier_get
+
+  @doc """
+  Undeclares the querier identified by the given ID.
+  """
+  @spec undeclare(id()) :: :ok | {:error, reason :: term()}
+  defdelegate undeclare(id), to: Zenohex.Nif, as: :querier_undeclare
+end

--- a/lib/zenohex/session.ex
+++ b/lib/zenohex/session.ex
@@ -74,7 +74,9 @@ defmodule Zenohex.Session do
         ]
 
   @type get_opts :: [
+          accept_replies: reply_key_expr(),
           attachment: binary() | nil,
+          allowed_destination: locality(),
           congestion_control: congestion_control(),
           consolidation: query_consolidation(),
           encoding: String.t(),
@@ -97,15 +99,19 @@ defmodule Zenohex.Session do
         ]
 
   @type publisher_opts :: [
+          allowed_destination: locality(),
           congestion_control: congestion_control(),
           encoding: String.t(),
           express: boolean(),
           priority: priority()
         ]
 
-  @type subscriber_opts :: []
+  @type subscriber_opts :: [
+          allowed_origin: locality()
+        ]
 
   @type queryable_opts :: [
+          allowed_origin: locality(),
           complete: boolean()
         ]
 

--- a/lib/zenohex/session.ex
+++ b/lib/zenohex/session.ex
@@ -51,6 +51,11 @@ defmodule Zenohex.Session do
           | :data_low
           | :background
 
+  @type query_target :: :best_matching | :all | :all_complete
+  @type query_consolidation :: :auto | :none | :monotonic | :latest
+  @type reply_key_expr :: :matching_query | :any
+  @type locality :: :session_local | :remote | :any
+
   @type put_opts :: [
           attachment: binary() | nil,
           congestion_control: congestion_control(),
@@ -71,13 +76,24 @@ defmodule Zenohex.Session do
   @type get_opts :: [
           attachment: binary() | nil,
           congestion_control: congestion_control(),
-          consolidation: :auto | :none | :monotonic | :latest,
+          consolidation: query_consolidation(),
           encoding: String.t(),
           express: boolean(),
           payload: binary() | nil,
           priority: priority(),
-          target: :best_matching | :all | :all_complete,
+          target: query_target(),
           query_timeout: non_neg_integer()
+        ]
+
+  @type querier_opts :: [
+          accept_replies: reply_key_expr(),
+          allowed_destination: locality(),
+          congestion_control: congestion_control(),
+          consolidation: query_consolidation(),
+          express: boolean(),
+          priority: priority(),
+          query_timeout: non_neg_integer(),
+          target: query_target()
         ]
 
   @type publisher_opts :: [
@@ -285,6 +301,31 @@ defmodule Zenohex.Session do
   defdelegate declare_publisher(session_id, key_expr, opts \\ []),
     to: Zenohex.Nif,
     as: :session_declare_publisher
+
+  @doc """
+  Declares a reusable querier associated with the given session and `key_expr`.
+
+  Unlike `get/4`, which performs a one-shot query, a querier keeps the
+  declaration alive and can execute multiple `Zenohex.Querier.get/3` calls
+  with different per-request options.
+
+  ## Parameters
+
+    - `session_id`: Identifier of the session returned by `open/0` or `open/1`.
+    - `key_expr`: Key expression to query under.
+    - `opts`: Options for configuring the reusable querier.
+
+  > ### Important {: .info}
+  >
+  > The returned `querier_id` must be held for as long as the querier is in use.
+  > If it is not held and gets garbage-collected by the BEAM,
+  > the underlying querier in Rust will be automatically dropped.
+  """
+  @spec declare_querier(session_id :: id(), String.t(), querier_opts()) ::
+          {:ok, querier_id :: Zenohex.Querier.id()} | {:error, reason :: term()}
+  defdelegate declare_querier(session_id, key_expr, opts \\ []),
+    to: Zenohex.Nif,
+    as: :session_declare_querier
 
   @doc """
   Declares a subscriber for the specified `key_expr`.

--- a/mix.exs
+++ b/mix.exs
@@ -87,6 +87,7 @@ defmodule Zenohex.MixProject do
         Examples: [
           Zenohex.Examples.Publisher,
           Zenohex.Examples.Subscriber,
+          Zenohex.Examples.Querier,
           Zenohex.Examples.Queryable,
           Zenohex.Examples.LivelinessSubscriber,
           Zenohex.Examples.Scout,

--- a/mix.exs
+++ b/mix.exs
@@ -102,7 +102,7 @@ defmodule Zenohex.MixProject do
       ignore_modules: [
         Zenohex.Nif,
         ~r/Zenohex.Nif.Logger.*/,
-        Zenohex.Examples.Plugins.StorageBackendFs
+        ~r/Zenohex.Examples.*/
       ]
     ]
   end

--- a/native/zenohex_nif/src/builder.rs
+++ b/native/zenohex_nif/src/builder.rs
@@ -367,6 +367,10 @@ impl Builder for zenoh::pubsub::PublisherBuilder<'_, '_> {
         opts_iter.try_fold(self, |builder, opt| {
             let (k, v): (rustler::Atom, rustler::Term) = opt.decode()?;
             match k {
+                k if k == crate::atoms::allowed_destination() => {
+                    let allowed_destination = v.decode::<Locality>()?;
+                    Ok(builder.allowed_destination(allowed_destination.into()))
+                }
                 k if k == crate::atoms::congestion_control() => {
                     let congestion_control = v.decode::<CongestionControl>()?;
                     Ok(builder.congestion_control(congestion_control.into()))
@@ -393,8 +397,14 @@ impl Builder for zenoh::pubsub::SubscriberBuilder<'_, '_, zenoh::handlers::Defau
         let mut opts_iter: rustler::ListIterator = opts.decode()?;
 
         opts_iter.try_fold(self, |builder, opt| {
-            let (_k, _v): (rustler::Atom, rustler::Term) = opt.decode()?;
-            Ok(builder)
+            let (k, v): (rustler::Atom, rustler::Term) = opt.decode()?;
+            match k {
+                k if k == crate::atoms::allowed_origin() => {
+                    let allowed_origin = v.decode::<Locality>()?;
+                    Ok(builder.allowed_origin(allowed_origin.into()))
+                }
+                _ => Ok(builder),
+            }
         })
     }
 }
@@ -406,6 +416,10 @@ impl Builder for zenoh::query::QueryableBuilder<'_, '_, zenoh::handlers::Default
         opts_iter.try_fold(self, |builder, opt| {
             let (k, v): (rustler::Atom, rustler::Term) = opt.decode()?;
             match k {
+                k if k == crate::atoms::allowed_origin() => {
+                    let allowed_origin = v.decode::<Locality>()?;
+                    Ok(builder.allowed_origin(allowed_origin.into()))
+                }
                 k if k == crate::atoms::complete() => {
                     let complete = v.decode()?;
                     Ok(builder.complete(complete))

--- a/native/zenohex_nif/src/builder.rs
+++ b/native/zenohex_nif/src/builder.rs
@@ -172,7 +172,8 @@ impl Builder
                     Ok(builder.express(express))
                 }
                 k if k == crate::atoms::priority() => {
-                    Ok(builder.priority(v.decode::<Priority>()?.into()))
+                    let priority = v.decode::<Priority>()?;
+                    Ok(builder.priority(priority.into()))
                 }
                 k if k == crate::atoms::timestamp() => {
                     if let Some(timestamp) = v.decode::<Option<String>>()? {
@@ -219,7 +220,8 @@ impl Builder
                     Ok(builder.express(express))
                 }
                 k if k == crate::atoms::priority() => {
-                    Ok(builder.priority(v.decode::<Priority>()?.into()))
+                    let priority = v.decode::<Priority>()?;
+                    Ok(builder.priority(priority.into()))
                 }
                 k if k == crate::atoms::timestamp() => todo!(),
                 _ => Ok(builder),
@@ -384,7 +386,8 @@ impl Builder for zenoh::pubsub::PublisherBuilder<'_, '_> {
                     Ok(builder.express(express))
                 }
                 k if k == crate::atoms::priority() => {
-                    Ok(builder.priority(v.decode::<Priority>()?.into()))
+                    let priority = v.decode::<Priority>()?;
+                    Ok(builder.priority(priority.into()))
                 }
                 _ => Ok(builder),
             }

--- a/native/zenohex_nif/src/builder.rs
+++ b/native/zenohex_nif/src/builder.rs
@@ -647,8 +647,14 @@ impl Builder
         let mut opts_iter: rustler::ListIterator = opts.decode()?;
 
         opts_iter.try_fold(self, |builder, opt| {
-            let (_k, _v): (rustler::Atom, rustler::Term) = opt.decode()?;
-            Ok(builder)
+            let (k, v): (rustler::Atom, rustler::Term) = opt.decode()?;
+            match k {
+                k if k == crate::atoms::history() => {
+                    let history = v.decode::<bool>()?;
+                    Ok(builder.history(history))
+                }
+                _ => Ok(builder),
+            }
         })
     }
 }

--- a/native/zenohex_nif/src/builder.rs
+++ b/native/zenohex_nif/src/builder.rs
@@ -330,6 +330,14 @@ impl Builder for zenoh::session::SessionGetBuilder<'_, '_, zenoh::handlers::Defa
                         Ok(builder)
                     }
                 }
+                k if k == crate::atoms::accept_replies() => {
+                    let accept_replies = v.decode::<ReplyKeyExpr>()?;
+                    Ok(builder.accept_replies(accept_replies.into()))
+                }
+                k if k == crate::atoms::allowed_destination() => {
+                    let allowed_destination = v.decode::<Locality>()?;
+                    Ok(builder.allowed_destination(allowed_destination.into()))
+                }
                 k if k == crate::atoms::congestion_control() => {
                     let congestion_control = v.decode::<CongestionControl>()?;
                     Ok(builder.congestion_control(congestion_control.into()))

--- a/native/zenohex_nif/src/builder.rs
+++ b/native/zenohex_nif/src/builder.rs
@@ -223,7 +223,17 @@ impl Builder
                     let priority = v.decode::<Priority>()?;
                     Ok(builder.priority(priority.into()))
                 }
-                k if k == crate::atoms::timestamp() => todo!(),
+                k if k == crate::atoms::timestamp() => {
+                    if let Some(timestamp) = v.decode::<Option<String>>()? {
+                        let timestamp =
+                            zenoh::time::Timestamp::parse_rfc3339(&timestamp).map_err(|error| {
+                                rustler::Error::Term(crate::zenoh_error!(error.cause))
+                            })?;
+                        Ok(builder.timestamp(timestamp))
+                    } else {
+                        Ok(builder)
+                    }
+                }
                 _ => Ok(builder),
             }
         })

--- a/native/zenohex_nif/src/builder.rs
+++ b/native/zenohex_nif/src/builder.rs
@@ -102,6 +102,38 @@ impl From<QueryConsolidation> for zenoh::query::ConsolidationMode {
     }
 }
 
+#[derive(rustler::NifUnitEnum)]
+enum ReplyKeyExpr {
+    Any,
+    MatchingQuery,
+}
+
+impl From<ReplyKeyExpr> for zenoh::query::ReplyKeyExpr {
+    fn from(value: ReplyKeyExpr) -> Self {
+        match value {
+            ReplyKeyExpr::Any => zenoh::query::ReplyKeyExpr::Any,
+            ReplyKeyExpr::MatchingQuery => zenoh::query::ReplyKeyExpr::MatchingQuery,
+        }
+    }
+}
+
+#[derive(rustler::NifUnitEnum)]
+enum Locality {
+    SessionLocal,
+    Remote,
+    Any,
+}
+
+impl From<Locality> for zenoh::sample::Locality {
+    fn from(value: Locality) -> Self {
+        match value {
+            Locality::SessionLocal => zenoh::sample::Locality::SessionLocal,
+            Locality::Remote => zenoh::sample::Locality::Remote,
+            Locality::Any => zenoh::sample::Locality::Any,
+        }
+    }
+}
+
 pub trait Builder: Sized {
     fn apply_opts(self, opts: rustler::Term) -> rustler::NifResult<Self>
     where
@@ -377,6 +409,87 @@ impl Builder for zenoh::query::QueryableBuilder<'_, '_, zenoh::handlers::Default
                 k if k == crate::atoms::complete() => {
                     let complete = v.decode()?;
                     Ok(builder.complete(complete))
+                }
+                _ => Ok(builder),
+            }
+        })
+    }
+}
+
+impl Builder for zenoh::query::QuerierBuilder<'_, '_> {
+    fn apply_opts(self, opts: rustler::Term) -> rustler::NifResult<Self> {
+        let mut opts_iter: rustler::ListIterator = opts.decode()?;
+
+        opts_iter.try_fold(self, |builder, opt| {
+            let (k, v): (rustler::Atom, rustler::Term) = opt.decode()?;
+            match k {
+                k if k == crate::atoms::accept_replies() => {
+                    let accept_replies = v.decode::<ReplyKeyExpr>()?;
+                    Ok(builder.accept_replies(accept_replies.into()))
+                }
+                k if k == crate::atoms::allowed_destination() => {
+                    let allowed_destination = v.decode::<Locality>()?;
+                    Ok(builder.allowed_destination(allowed_destination.into()))
+                }
+                k if k == crate::atoms::congestion_control() => {
+                    let congestion_control = v.decode::<CongestionControl>()?;
+                    Ok(builder.congestion_control(congestion_control.into()))
+                }
+                k if k == crate::atoms::consolidation() => {
+                    let consolidation = v.decode::<QueryConsolidation>()?;
+                    Ok(builder
+                        .consolidation::<zenoh::query::ConsolidationMode>(consolidation.into()))
+                }
+                k if k == crate::atoms::express() => {
+                    let express = v.decode()?;
+                    Ok(builder.express(express))
+                }
+                k if k == crate::atoms::priority() => {
+                    let priority = v.decode::<Priority>()?;
+                    Ok(builder.priority(priority.into()))
+                }
+                k if k == crate::atoms::query_timeout() => {
+                    let query_timeout = v.decode::<u64>()?;
+                    Ok(builder.timeout(Duration::from_millis(query_timeout)))
+                }
+                k if k == crate::atoms::target() => {
+                    let target = v.decode::<QueryTarget>()?;
+                    Ok(builder.target(target.into()))
+                }
+                _ => Ok(builder),
+            }
+        })
+    }
+}
+
+impl Builder for zenoh::query::QuerierGetBuilder<'_, '_, zenoh::handlers::DefaultHandler> {
+    fn apply_opts(self, opts: rustler::Term) -> rustler::NifResult<Self> {
+        let mut opts_iter: rustler::ListIterator = opts.decode()?;
+
+        opts_iter.try_fold(self, |builder, opt| {
+            let (k, v): (rustler::Atom, rustler::Term) = opt.decode()?;
+            match k {
+                k if k == crate::atoms::attachment() => {
+                    if let Some(binary) = v.decode::<Option<rustler::Binary>>()? {
+                        Ok(builder.attachment(binary.as_slice().to_vec()))
+                    } else {
+                        Ok(builder)
+                    }
+                }
+                k if k == crate::atoms::encoding() => {
+                    let encoding = v.decode::<String>()?;
+                    Ok(builder.encoding(encoding))
+                }
+                k if k == crate::atoms::parameters() => {
+                    let parameters = v.decode::<String>()?;
+                    Ok(builder.parameters(parameters))
+                }
+                k if k == crate::atoms::payload() => {
+                    if let Some(binary) = v.decode::<Option<rustler::Binary>>()? {
+                        Ok(builder.payload(binary.as_slice().to_vec()))
+                    } else {
+                        Ok(builder)
+                    }
                 }
                 _ => Ok(builder),
             }

--- a/native/zenohex_nif/src/lib.rs
+++ b/native/zenohex_nif/src/lib.rs
@@ -29,6 +29,7 @@ mod atoms {
         accept_replies,
         attachment,
         allowed_destination,
+        allowed_origin,
         complete,
         congestion_control,
         consolidation,

--- a/native/zenohex_nif/src/lib.rs
+++ b/native/zenohex_nif/src/lib.rs
@@ -16,6 +16,7 @@ mod helper;
 mod keyexpr;
 mod liveliness;
 mod publisher;
+mod querier;
 mod query;
 mod queryable;
 mod sample;
@@ -25,13 +26,16 @@ mod subscriber;
 
 mod atoms {
     rustler::atoms! {
+        accept_replies,
         attachment,
+        allowed_destination,
         complete,
         congestion_control,
         consolidation,
         encoding,
         express,
         is_final = "final?",
+        parameters,
         payload,
         priority,
         query_timeout,

--- a/native/zenohex_nif/src/lib.rs
+++ b/native/zenohex_nif/src/lib.rs
@@ -15,6 +15,7 @@ mod config;
 mod helper;
 mod keyexpr;
 mod liveliness;
+mod matching;
 mod publisher;
 mod querier;
 mod query;
@@ -43,6 +44,7 @@ mod atoms {
         query_timeout,
         target,
         timeout,
+        unsupported_entity,
         timestamp,
         zenohex_nif = "Elixir.Zenohex.Nif",
     }

--- a/native/zenohex_nif/src/lib.rs
+++ b/native/zenohex_nif/src/lib.rs
@@ -28,6 +28,7 @@ mod atoms {
     rustler::atoms! {
         accept_replies,
         attachment,
+        history,
         allowed_destination,
         allowed_origin,
         complete,

--- a/native/zenohex_nif/src/liveliness.rs
+++ b/native/zenohex_nif/src/liveliness.rs
@@ -48,14 +48,18 @@ fn liveliness_get<'a>(
     let session_id = &session_id_resource;
     let session =
         crate::session::SessionMap::get_session(&crate::session::SESSION_MAP, session_id)?;
-    let session_locked = session.read().unwrap();
+    // WHY: Keep the read lock only around handler creation.
+    //      If session_locked lives through the reply loop, write-lock operations such as
+    //      undeclare or session close can be blocked until timeout.
+    let channel_handler = {
+        let session_locked = session.read().unwrap();
+        let liveliness_get_builder = session_locked.liveliness().get(key_expr);
 
-    let liveliness_get_builder = session_locked.liveliness().get(key_expr);
-
-    let channel_handler = liveliness_get_builder
-        .apply_opts(opts)?
-        .wait()
-        .map_err(|error| rustler::Error::Term(crate::zenoh_error!(error)))?;
+        liveliness_get_builder
+            .apply_opts(opts)?
+            .wait()
+            .map_err(|error| rustler::Error::Term(crate::zenoh_error!(error)))?
+    };
 
     let deadline = Instant::now() + Duration::from_millis(timeout);
     let mut replies = Vec::new();

--- a/native/zenohex_nif/src/matching.rs
+++ b/native/zenohex_nif/src/matching.rs
@@ -1,0 +1,156 @@
+use std::ops::Deref;
+use std::sync::Mutex;
+
+use zenoh::Wait;
+
+struct MatchingListenerResource {
+    listener: Mutex<Option<zenoh::matching::MatchingListener<()>>>,
+}
+
+#[rustler::resource_impl]
+impl rustler::Resource for MatchingListenerResource {}
+
+impl Deref for MatchingListenerResource {
+    type Target = Mutex<Option<zenoh::matching::MatchingListener<()>>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.listener
+    }
+}
+
+impl MatchingListenerResource {
+    fn new(listener: zenoh::matching::MatchingListener<()>) -> Self {
+        MatchingListenerResource {
+            listener: Mutex::new(Some(listener)),
+        }
+    }
+}
+
+impl Drop for MatchingListenerResource {
+    fn drop(&mut self) {
+        let mut listener_option = self.lock().unwrap();
+        match listener_option.take() {
+            Some(listener) => {
+                if let Err(error) = listener.undeclare().wait() {
+                    log::debug!("matching listener drop undeclare failed: {}", error);
+                }
+            }
+            None => log::debug!("matching listener already undeclared"),
+        }
+    }
+}
+
+#[derive(rustler::NifStruct)]
+#[module = "Zenohex.Matching.Status"]
+pub struct ZenohexMatchingStatus {
+    matching: bool,
+}
+
+impl From<zenoh::matching::MatchingStatus> for ZenohexMatchingStatus {
+    fn from(value: zenoh::matching::MatchingStatus) -> Self {
+        ZenohexMatchingStatus {
+            matching: value.matching(),
+        }
+    }
+}
+
+#[rustler::nif]
+fn matching_status(
+    entity_global_id_resource: rustler::ResourceArc<crate::session::EntityGlobalIdResource>,
+) -> rustler::NifResult<(rustler::Atom, bool)> {
+    let session_id = &entity_global_id_resource.zid();
+    let entity_global_id = &entity_global_id_resource;
+
+    let session =
+        crate::session::SessionMap::get_session(&crate::session::SESSION_MAP, session_id)?;
+    let session_locked = session.read().unwrap();
+    let entity = session_locked.get_entity(entity_global_id)?;
+
+    let status = match entity {
+        crate::session::Entity::Publisher(publisher, _) => publisher
+            .matching_status()
+            .wait()
+            .map(|status| status.matching()),
+        crate::session::Entity::Querier(querier, _) => querier
+            .matching_status()
+            .wait()
+            .map(|status| status.matching()),
+        _ => {
+            return Err(rustler::Error::Term(Box::new(
+                crate::atoms::unsupported_entity(),
+            )))
+        }
+    }
+    .map_err(|error| rustler::Error::Term(crate::zenoh_error!(error)))?;
+
+    Ok((rustler::types::atom::ok(), status))
+}
+
+#[rustler::nif]
+fn matching_declare_listener(
+    entity_global_id_resource: rustler::ResourceArc<crate::session::EntityGlobalIdResource>,
+    pid: rustler::LocalPid,
+) -> rustler::NifResult<(
+    rustler::Atom,
+    rustler::ResourceArc<MatchingListenerResource>,
+)> {
+    let session_id = &entity_global_id_resource.zid();
+    let entity_global_id = &entity_global_id_resource;
+
+    let session =
+        crate::session::SessionMap::get_session(&crate::session::SESSION_MAP, session_id)?;
+    let session_locked = session.read().unwrap();
+    let entity = session_locked.get_entity(entity_global_id)?;
+
+    let send_matching_status = move |matching_status| {
+        // WHY: Spawn a thread inside this callback.
+        //      If we don't spawn a thread, a panic will occur.
+        //      See: https://docs.rs/rustler/latest/rustler/env/struct.OwnedEnv.html#panics
+        std::thread::spawn(move || {
+            let _ = rustler::OwnedEnv::new().run(|env: rustler::Env| {
+                env.send(&pid, ZenohexMatchingStatus::from(matching_status))
+            });
+        });
+    };
+
+    let listener = match entity {
+        crate::session::Entity::Publisher(publisher, _) => publisher
+            .matching_listener()
+            .callback(send_matching_status)
+            .wait(),
+        crate::session::Entity::Querier(querier, _) => querier
+            .matching_listener()
+            .callback(send_matching_status)
+            .wait(),
+        _ => {
+            return Err(rustler::Error::Term(Box::new(
+                crate::atoms::unsupported_entity(),
+            )))
+        }
+    }
+    .map_err(|error| rustler::Error::Term(crate::zenoh_error!(error)))?;
+
+    Ok((
+        rustler::types::atom::ok(),
+        rustler::ResourceArc::new(MatchingListenerResource::new(listener)),
+    ))
+}
+
+#[rustler::nif]
+fn matching_undeclare_listener(
+    matching_listener_resource: rustler::ResourceArc<MatchingListenerResource>,
+) -> rustler::NifResult<rustler::Atom> {
+    let mut listener_option = matching_listener_resource.lock().unwrap();
+
+    match listener_option.take() {
+        Some(listener) => {
+            listener
+                .undeclare()
+                .wait()
+                .map_err(|error| rustler::Error::Term(crate::zenoh_error!(error)))?;
+
+            Ok(rustler::types::atom::ok())
+        }
+        None => Err(rustler::Error::Term(Box::new("already undeclared"))),
+    }
+}

--- a/native/zenohex_nif/src/publisher.rs
+++ b/native/zenohex_nif/src/publisher.rs
@@ -26,7 +26,9 @@ fn publisher_put(
 
             Ok(rustler::types::atom::ok())
         }
-        _ => unreachable!("unexpected entity"),
+        _ => Err(rustler::Error::Term(Box::new(
+            crate::atoms::unsupported_entity(),
+        ))),
     }
 }
 
@@ -53,7 +55,9 @@ fn publisher_delete(
 
             Ok(rustler::types::atom::ok())
         }
-        _ => unreachable!("unexpected entity"),
+        _ => Err(rustler::Error::Term(Box::new(
+            crate::atoms::unsupported_entity(),
+        ))),
     }
 }
 
@@ -67,17 +71,27 @@ fn publisher_undeclare(
     let session =
         crate::session::SessionMap::get_session(&crate::session::SESSION_MAP, session_id)?;
     let mut session_locked = session.write().unwrap();
-    let entity = session_locked.remove_entity(entity_global_id)?;
 
-    match entity {
-        crate::session::Entity::Publisher(publisher, _) => {
-            publisher
-                .undeclare()
-                .wait()
-                .map_err(|error| rustler::Error::Term(crate::zenoh_error!(error)))?;
+    let is_publisher = matches!(
+        session_locked.get_entity(entity_global_id)?,
+        crate::session::Entity::Publisher(_, _)
+    );
 
-            Ok(rustler::types::atom::ok())
-        }
-        _ => unreachable!("unexpected entity"),
+    if !is_publisher {
+        return Err(rustler::Error::Term(Box::new(
+            crate::atoms::unsupported_entity(),
+        )));
     }
+
+    let entity = session_locked.remove_entity(entity_global_id)?;
+    let crate::session::Entity::Publisher(publisher, _) = entity else {
+        unreachable!("entity kind changed after publisher check")
+    };
+
+    publisher
+        .undeclare()
+        .wait()
+        .map_err(|error| rustler::Error::Term(crate::zenoh_error!(error)))?;
+
+    Ok(rustler::types::atom::ok())
 }

--- a/native/zenohex_nif/src/querier.rs
+++ b/native/zenohex_nif/src/querier.rs
@@ -32,7 +32,11 @@ fn querier_get<'a>(
                     .apply_opts(opts)?
                     .wait()
                     .map_err(|error| rustler::Error::Term(crate::zenoh_error!(error)))?,
-                _ => unreachable!("unexpected entity"),
+                _ => {
+                    return Err(rustler::Error::Term(Box::new(
+                        crate::atoms::unsupported_entity(),
+                    )))
+                }
             }
         };
 
@@ -85,17 +89,27 @@ fn querier_undeclare(
     let session =
         crate::session::SessionMap::get_session(&crate::session::SESSION_MAP, session_id)?;
     let mut session_locked = session.write().unwrap();
-    let entity = session_locked.remove_entity(entity_global_id)?;
 
-    match entity {
-        crate::session::Entity::Querier(querier, _) => {
-            querier
-                .undeclare()
-                .wait()
-                .map_err(|error| rustler::Error::Term(crate::zenoh_error!(error)))?;
+    let is_querier = matches!(
+        session_locked.get_entity(entity_global_id)?,
+        crate::session::Entity::Querier(_, _)
+    );
 
-            Ok(rustler::types::atom::ok())
-        }
-        _ => unreachable!("unexpected entity"),
+    if !is_querier {
+        return Err(rustler::Error::Term(Box::new(
+            crate::atoms::unsupported_entity(),
+        )));
     }
+
+    let entity = session_locked.remove_entity(entity_global_id)?;
+    let crate::session::Entity::Querier(querier, _) = entity else {
+        unreachable!("entity kind changed after querier check")
+    };
+
+    querier
+        .undeclare()
+        .wait()
+        .map_err(|error| rustler::Error::Term(crate::zenoh_error!(error)))?;
+
+    Ok(rustler::types::atom::ok())
 }

--- a/native/zenohex_nif/src/querier.rs
+++ b/native/zenohex_nif/src/querier.rs
@@ -1,0 +1,95 @@
+use std::time::Duration;
+use std::time::Instant;
+
+use rustler::Encoder;
+use zenoh::Wait;
+
+use crate::builder::Builder;
+
+#[rustler::nif(schedule = "DirtyIo")]
+fn querier_get<'a>(
+    env: rustler::Env<'a>,
+    entity_global_id_resource: rustler::ResourceArc<crate::session::EntityGlobalIdResource>,
+    timeout: u64,
+    opts: rustler::Term,
+) -> rustler::NifResult<(rustler::Atom, Vec<rustler::Term<'a>>)> {
+    let session_id = &entity_global_id_resource.zid();
+    let entity_global_id = &entity_global_id_resource;
+
+    let session =
+        crate::session::SessionMap::get_session(&crate::session::SESSION_MAP, session_id)?;
+    let session_locked = session.read().unwrap();
+    let entity = session_locked.get_entity(entity_global_id)?;
+
+    let channel_handler = match entity {
+        crate::session::Entity::Querier(querier, _) => querier
+            .get()
+            .apply_opts(opts)?
+            .wait()
+            .map_err(|error| rustler::Error::Term(crate::zenoh_error!(error)))?,
+        _ => unreachable!("unexpected entity"),
+    };
+
+    let deadline = Instant::now() + Duration::from_millis(timeout);
+    let mut replies = Vec::new();
+
+    loop {
+        // NOTE: `recv_deadline` document says following,
+        //       > If the deadline has expired, this will return None.
+        let reply = match channel_handler.recv_deadline(deadline) {
+            Ok(Some(reply)) => reply,
+            Ok(None) => {
+                // If we timeout but have collected replies, return them successfully.
+                // Only error on timeout if we have no data at all.
+                if !replies.is_empty() {
+                    break;
+                }
+                return Err(rustler::Error::Term(Box::new(crate::atoms::timeout())));
+            }
+            Err(error) => {
+                // If the channel disconnected after receiving some replies,
+                // treat it as a successful completion and return what we collected.
+                if channel_handler.is_disconnected() && !replies.is_empty() {
+                    break;
+                }
+                return Err(rustler::Error::Term(crate::zenoh_error!(error)));
+            }
+        };
+
+        let term = match reply.result() {
+            Ok(sample) => crate::sample::ZenohexSample::from(env, sample.clone()).encode(env),
+            Err(reply_error) => {
+                crate::query::ZenohexQueryReplyError::from(env, reply_error.clone()).encode(env)
+            }
+        };
+
+        replies.push(term);
+    }
+
+    Ok((rustler::types::atom::ok(), replies))
+}
+
+#[rustler::nif]
+fn querier_undeclare(
+    entity_global_id_resource: rustler::ResourceArc<crate::session::EntityGlobalIdResource>,
+) -> rustler::NifResult<rustler::Atom> {
+    let session_id = &entity_global_id_resource.zid();
+    let entity_global_id = &entity_global_id_resource;
+
+    let session =
+        crate::session::SessionMap::get_session(&crate::session::SESSION_MAP, session_id)?;
+    let mut session_locked = session.write().unwrap();
+    let entity = session_locked.remove_entity(entity_global_id)?;
+
+    match entity {
+        crate::session::Entity::Querier(querier, _) => {
+            querier
+                .undeclare()
+                .wait()
+                .map_err(|error| rustler::Error::Term(crate::zenoh_error!(error)))?;
+
+            Ok(rustler::types::atom::ok())
+        }
+        _ => unreachable!("unexpected entity"),
+    }
+}

--- a/native/zenohex_nif/src/querier.rs
+++ b/native/zenohex_nif/src/querier.rs
@@ -18,17 +18,23 @@ fn querier_get<'a>(
 
     let session =
         crate::session::SessionMap::get_session(&crate::session::SESSION_MAP, session_id)?;
-    let session_locked = session.read().unwrap();
-    let entity = session_locked.get_entity(entity_global_id)?;
+    // WHY: Keep the read lock only around handler creation.
+    //      If session_locked lives through the reply loop, write-lock operations such as
+    //      undeclare or session close can be blocked until timeout.
+    let channel_handler =
+        {
+            let session_locked = session.read().unwrap();
+            let entity = session_locked.get_entity(entity_global_id)?;
 
-    let channel_handler = match entity {
-        crate::session::Entity::Querier(querier, _) => querier
-            .get()
-            .apply_opts(opts)?
-            .wait()
-            .map_err(|error| rustler::Error::Term(crate::zenoh_error!(error)))?,
-        _ => unreachable!("unexpected entity"),
-    };
+            match entity {
+                crate::session::Entity::Querier(querier, _) => querier
+                    .get()
+                    .apply_opts(opts)?
+                    .wait()
+                    .map_err(|error| rustler::Error::Term(crate::zenoh_error!(error)))?,
+                _ => unreachable!("unexpected entity"),
+            }
+        };
 
     let deadline = Instant::now() + Duration::from_millis(timeout);
     let mut replies = Vec::new();

--- a/native/zenohex_nif/src/queryable.rs
+++ b/native/zenohex_nif/src/queryable.rs
@@ -10,17 +10,27 @@ fn queryable_undeclare(
     let session =
         crate::session::SessionMap::get_session(&crate::session::SESSION_MAP, session_id)?;
     let mut session_locked = session.write().unwrap();
-    let entity = session_locked.remove_entity(entity_global_id)?;
 
-    match entity {
-        crate::session::Entity::Queryable(queryable, _) => {
-            queryable
-                .undeclare()
-                .wait()
-                .map_err(|error| rustler::Error::Term(crate::zenoh_error!(error)))?;
+    let is_queryable = matches!(
+        session_locked.get_entity(entity_global_id)?,
+        crate::session::Entity::Queryable(_, _)
+    );
 
-            Ok(rustler::types::atom::ok())
-        }
-        _ => unreachable!("unexpected entity"),
+    if !is_queryable {
+        return Err(rustler::Error::Term(Box::new(
+            crate::atoms::unsupported_entity(),
+        )));
     }
+
+    let entity = session_locked.remove_entity(entity_global_id)?;
+    let crate::session::Entity::Queryable(queryable, _) = entity else {
+        unreachable!("entity kind changed after queryable check")
+    };
+
+    queryable
+        .undeclare()
+        .wait()
+        .map_err(|error| rustler::Error::Term(crate::zenoh_error!(error)))?;
+
+    Ok(rustler::types::atom::ok())
 }

--- a/native/zenohex_nif/src/session.rs
+++ b/native/zenohex_nif/src/session.rs
@@ -333,13 +333,18 @@ fn session_get<'a>(
 ) -> rustler::NifResult<(rustler::Atom, Vec<rustler::Term<'a>>)> {
     let session_id = &session_id_resource;
     let session = SessionMap::get_session(&SESSION_MAP, session_id)?;
-    let session_locked = session.read().unwrap();
-    let session_get_builder = session_locked.get(selector);
+    // WHY: Keep the read lock only around handler creation.
+    //      If session_locked lives through the reply loop, write-lock operations such as
+    //      undeclare or session close can be blocked until timeout.
+    let channel_handler = {
+        let session_locked = session.read().unwrap();
+        let session_get_builder = session_locked.get(selector);
 
-    let channel_handler = session_get_builder
-        .apply_opts(opts)?
-        .wait()
-        .map_err(|error| rustler::Error::Term(crate::zenoh_error!(error)))?;
+        session_get_builder
+            .apply_opts(opts)?
+            .wait()
+            .map_err(|error| rustler::Error::Term(crate::zenoh_error!(error)))?
+    };
 
     let deadline = Instant::now() + Duration::from_millis(timeout);
     let mut replies = Vec::new();

--- a/native/zenohex_nif/src/session.rs
+++ b/native/zenohex_nif/src/session.rs
@@ -17,6 +17,10 @@ pub enum Entity<'a> {
         zenoh::pubsub::Publisher<'a>,
         #[allow(dead_code)] rustler::ResourceArc<SessionIdResource>,
     ),
+    Querier(
+        zenoh::query::Querier<'a>,
+        #[allow(dead_code)] rustler::ResourceArc<SessionIdResource>,
+    ),
     Subscriber(
         zenoh::pubsub::Subscriber<()>,
         #[allow(dead_code)] rustler::ResourceArc<SessionIdResource>,
@@ -31,6 +35,7 @@ impl fmt::Display for Entity<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Entity::Publisher(_, _) => write!(f, "Publisher"),
+            Entity::Querier(_, _) => write!(f, "Querier"),
             Entity::Subscriber(_, _) => write!(f, "Subscriber"),
             Entity::Queryable(_, _) => write!(f, "Queryable"),
         }
@@ -425,6 +430,32 @@ fn session_declare_publisher(
     Ok((
         rustler::types::atom::ok(),
         rustler::ResourceArc::new(EntityGlobalIdResource::new(publisher_id)),
+    ))
+}
+
+#[rustler::nif]
+fn session_declare_querier(
+    session_id_resource: rustler::ResourceArc<SessionIdResource>,
+    key_expr: String,
+    opts: rustler::Term,
+) -> rustler::NifResult<(rustler::Atom, rustler::ResourceArc<EntityGlobalIdResource>)> {
+    let session_id = &session_id_resource;
+    let session = SessionMap::get_session(&SESSION_MAP, session_id)?;
+    let mut session_locked = session.write().unwrap();
+
+    let querier_builder = session_locked.declare_querier(key_expr);
+
+    let querier = querier_builder
+        .apply_opts(opts)?
+        .wait()
+        .map_err(|error| rustler::Error::Term(crate::zenoh_error!(error)))?;
+
+    let querier_id = querier.id();
+    session_locked.insert_entity(querier_id, Entity::Querier(querier, session_id_resource))?;
+
+    Ok((
+        rustler::types::atom::ok(),
+        rustler::ResourceArc::new(EntityGlobalIdResource::new(querier_id)),
     ))
 }
 

--- a/native/zenohex_nif/src/subscriber.rs
+++ b/native/zenohex_nif/src/subscriber.rs
@@ -10,17 +10,27 @@ fn subscriber_undeclare(
     let session =
         crate::session::SessionMap::get_session(&crate::session::SESSION_MAP, session_id)?;
     let mut session_locked = session.write().unwrap();
-    let entity = session_locked.remove_entity(entity_global_id)?;
 
-    match entity {
-        crate::session::Entity::Subscriber(subscriber, _) => {
-            subscriber
-                .undeclare()
-                .wait()
-                .map_err(|error| rustler::Error::Term(crate::zenoh_error!(error)))?;
+    let is_subscriber = matches!(
+        session_locked.get_entity(entity_global_id)?,
+        crate::session::Entity::Subscriber(_, _)
+    );
 
-            Ok(rustler::types::atom::ok())
-        }
-        _ => unreachable!("unexpected entity"),
+    if !is_subscriber {
+        return Err(rustler::Error::Term(Box::new(
+            crate::atoms::unsupported_entity(),
+        )));
     }
+
+    let entity = session_locked.remove_entity(entity_global_id)?;
+    let crate::session::Entity::Subscriber(subscriber, _) = entity else {
+        unreachable!("entity kind changed after subscriber check")
+    };
+
+    subscriber
+        .undeclare()
+        .wait()
+        .map_err(|error| rustler::Error::Term(crate::zenoh_error!(error)))?;
+
+    Ok(rustler::types::atom::ok())
 }

--- a/test/zenohex/examples/querier_test.exs
+++ b/test/zenohex/examples/querier_test.exs
@@ -1,0 +1,38 @@
+defmodule Zenohex.Examples.QuerierTest do
+  use ExUnit.Case
+
+  setup do
+    {:ok, session_id} =
+      Zenohex.Config.default()
+      |> Zenohex.Test.Support.TestHelper.scouting_delay(0)
+      |> Zenohex.Session.open()
+
+    {:ok, queryable_id} = Zenohex.Session.declare_queryable(session_id, "key/expr/**", self())
+
+    on_exit(fn ->
+      Zenohex.Queryable.undeclare(queryable_id)
+      Zenohex.Session.close(session_id)
+    end)
+
+    %{session_id: session_id}
+  end
+
+  test "example works correctly", context do
+    assert {:ok, _pid} =
+             Zenohex.Examples.Querier.start_link(
+               session_id: context.session_id,
+               key_expr: "key/expr/**"
+             )
+
+    task = Task.async(fn -> Zenohex.Examples.Querier.get(timeout: 100, payload: "payload") end)
+
+    assert_receive %Zenohex.Query{zenoh_query: zenoh_query, payload: "payload"}
+
+    assert :ok = Zenohex.Query.reply(zenoh_query, "key/expr/1", "reply")
+
+    assert {:ok, [%Zenohex.Sample{kind: :put, key_expr: "key/expr/1", payload: "reply"}]} =
+             Task.await(task)
+
+    assert :ok = Zenohex.Examples.Querier.stop()
+  end
+end

--- a/test/zenohex/matching_test.exs
+++ b/test/zenohex/matching_test.exs
@@ -1,0 +1,72 @@
+defmodule Zenohex.MatchingTest do
+  use ExUnit.Case
+
+  setup do
+    {:ok, session_id} =
+      Zenohex.Config.default()
+      |> Zenohex.Test.Support.TestHelper.scouting_delay(0)
+      |> Zenohex.Session.open()
+
+    on_exit(fn -> Zenohex.Session.close(session_id) end)
+
+    %{session_id: session_id}
+  end
+
+  test "status/1 returns matching for publisher", context do
+    {:ok, subscriber_id} =
+      Zenohex.Session.declare_subscriber(context.session_id, "key/expr", self())
+
+    {:ok, publisher_id} = Zenohex.Session.declare_publisher(context.session_id, "key/expr")
+
+    assert {:ok, true} = Zenohex.Matching.status(publisher_id)
+
+    # WHY: Explicitly undeclare `subscriber_id` after the assertion.
+    #      Otherwise, the Elixir GC may release `subscriber_id` if it appears unused,
+    #      which triggers Rust's `Drop` before matching status is observed.
+    :ok = Zenohex.Subscriber.undeclare(subscriber_id)
+  end
+
+  test "status/1 returns matching for querier", context do
+    {:ok, queryable_id} =
+      Zenohex.Session.declare_queryable(context.session_id, "key/expr/**", self())
+
+    {:ok, querier_id} = Zenohex.Session.declare_querier(context.session_id, "key/expr/**")
+
+    assert {:ok, true} = Zenohex.Matching.status(querier_id)
+
+    # WHY: Explicitly undeclare `queryable_id` after the assertion.
+    #      Otherwise, the Elixir GC may release `queryable_id` if it appears unused,
+    #      which triggers Rust's `Drop` before matching status is observed.
+    :ok = Zenohex.Queryable.undeclare(queryable_id)
+  end
+
+  test "declare_listener/2 receives matching updates for publisher", context do
+    {:ok, publisher_id} = Zenohex.Session.declare_publisher(context.session_id, "key/expr")
+    {:ok, listener_id} = Zenohex.Matching.declare_listener(publisher_id, self())
+
+    {:ok, subscriber_id} =
+      Zenohex.Session.declare_subscriber(context.session_id, "key/expr", self())
+
+    assert_receive %Zenohex.Matching.Status{matching: true}
+
+    assert :ok = Zenohex.Subscriber.undeclare(subscriber_id)
+    assert_receive %Zenohex.Matching.Status{matching: false}
+
+    assert :ok = Zenohex.Matching.undeclare_listener(listener_id)
+    assert {:error, _} = Zenohex.Matching.undeclare_listener(listener_id)
+
+    # WHY: Explicitly undeclare `publisher_id`.
+    #      Otherwise, the Elixir GC may release `publisher_id` if it appears unused,
+    #      which triggers Rust's `Drop`, so matching status updates may no longer be received.
+    :ok = Zenohex.Publisher.undeclare(publisher_id)
+  end
+
+  test "undeclare_listener/1 returns error after parent publisher undeclare", context do
+    {:ok, publisher_id} = Zenohex.Session.declare_publisher(context.session_id, "key/expr")
+    {:ok, listener_id} = Zenohex.Matching.declare_listener(publisher_id, self())
+
+    # WHY: Parent publisher undeclare may already remove the matching listener on the Rust side.
+    assert :ok = Zenohex.Publisher.undeclare(publisher_id)
+    assert {:error, _} = Zenohex.Matching.undeclare_listener(listener_id)
+  end
+end

--- a/test/zenohex/querier_test.exs
+++ b/test/zenohex/querier_test.exs
@@ -1,0 +1,70 @@
+defmodule Zenohex.QuerierTest do
+  use ExUnit.Case
+
+  setup do
+    {:ok, session_id} =
+      Zenohex.Config.default()
+      |> Zenohex.Test.Support.TestHelper.scouting_delay(0)
+      |> Zenohex.Session.open()
+
+    {:ok, queryable_id} = Zenohex.Session.declare_queryable(session_id, "key/expr/**", self())
+    {:ok, querier_id} = Zenohex.Session.declare_querier(session_id, "key/expr/**")
+
+    on_exit(fn ->
+      Zenohex.Queryable.undeclare(queryable_id)
+      Zenohex.Querier.undeclare(querier_id)
+      Zenohex.Session.close(session_id)
+    end)
+
+    %{
+      querier_id: querier_id,
+      queryable_id: queryable_id
+    }
+  end
+
+  test "undeclare/1", context do
+    assert :ok = Zenohex.Querier.undeclare(context.querier_id)
+    assert {:error, _} = Zenohex.Querier.undeclare(context.querier_id)
+  end
+
+  test "get/3 returns put replies", context do
+    task = Task.async(Zenohex.Querier, :get, [context.querier_id, 100])
+
+    assert_receive %Zenohex.Query{zenoh_query: zenoh_query}
+
+    assert :ok = Zenohex.Query.reply(zenoh_query, "key/expr/1", "payload")
+
+    assert {:ok, [%Zenohex.Sample{kind: :put, key_expr: "key/expr/1", payload: "payload"}]} =
+             Task.await(task)
+  end
+
+  test "get/3 returns error replies", context do
+    task = Task.async(Zenohex.Querier, :get, [context.querier_id, 100])
+
+    assert_receive %Zenohex.Query{zenoh_query: zenoh_query}
+
+    assert :ok = Zenohex.Query.reply_error(zenoh_query, "payload")
+
+    assert {:ok, [%Zenohex.Query.ReplyError{payload: "payload"}]} = Task.await(task)
+  end
+
+  test "get/3 forwards payload and parameters", context do
+    task =
+      Task.async(Zenohex.Querier, :get, [
+        context.querier_id,
+        100,
+        [payload: "payload", parameters: "key=value"]
+      ])
+
+    assert_receive %Zenohex.Query{
+      zenoh_query: zenoh_query,
+      payload: "payload",
+      parameters: "key=value"
+    }
+
+    assert :ok = Zenohex.Query.reply(zenoh_query, "key/expr/1", "payload")
+
+    assert {:ok, [%Zenohex.Sample{key_expr: "key/expr/1", payload: "payload"}]} =
+             Task.await(task)
+  end
+end

--- a/test/zenohex/session_test.exs
+++ b/test/zenohex/session_test.exs
@@ -23,7 +23,7 @@ defmodule Zenohex.SessionTest do
              |> Zenohex.Session.open()
   end
 
-  test "close/0", context do
+  test "close/1", context do
     assert Zenohex.Session.close(context.session_id) == :ok
     assert Zenohex.Session.close(context.session_id) == {:error, "session not found"}
   end

--- a/test/zenohex/session_test.exs
+++ b/test/zenohex/session_test.exs
@@ -54,4 +54,9 @@ defmodule Zenohex.SessionTest do
     assert {:ok, _publisher_id} =
              Zenohex.Session.declare_publisher(context.sessoin_id, "key/expr")
   end
+
+  test "declare_querier/2", context do
+    assert {:ok, _querier_id} =
+             Zenohex.Session.declare_querier(context.sessoin_id, "key/expr")
+  end
 end

--- a/test/zenohex/session_test.exs
+++ b/test/zenohex/session_test.exs
@@ -2,61 +2,61 @@ defmodule Zenohex.SessionTest do
   use ExUnit.Case
 
   setup do
-    {:ok, sessoin_id} =
+    {:ok, session_id} =
       Zenohex.Config.default()
       |> Zenohex.Test.Support.TestHelper.scouting_delay(0)
       |> Zenohex.Session.open()
 
-    on_exit(fn -> Zenohex.Session.close(sessoin_id) end)
+    on_exit(fn -> Zenohex.Session.close(session_id) end)
 
-    %{sessoin_id: sessoin_id}
+    %{session_id: session_id}
   end
 
   test "open/0" do
-    assert {:ok, _sessoin_id} = Zenohex.Session.open()
+    assert {:ok, _session_id} = Zenohex.Session.open()
   end
 
   test "open/1" do
-    assert {:ok, _sessoin_id} =
+    assert {:ok, _session_id} =
              Zenohex.Config.default()
              |> Zenohex.Test.Support.TestHelper.scouting_delay(0)
              |> Zenohex.Session.open()
   end
 
   test "close/0", context do
-    assert Zenohex.Session.close(context.sessoin_id) == :ok
-    assert Zenohex.Session.close(context.sessoin_id) == {:error, "session not found"}
+    assert Zenohex.Session.close(context.session_id) == :ok
+    assert Zenohex.Session.close(context.session_id) == {:error, "session not found"}
   end
 
   test "put/3", context do
-    assert Zenohex.Session.put(context.sessoin_id, "key/expr", "payload") == :ok
+    assert Zenohex.Session.put(context.session_id, "key/expr", "payload") == :ok
   end
 
   test "delete/2", context do
-    assert Zenohex.Session.delete(context.sessoin_id, "key/expr") == :ok
+    assert Zenohex.Session.delete(context.session_id, "key/expr") == :ok
   end
 
   test "get/3", context do
-    assert {:error, _} = Zenohex.Session.get(context.sessoin_id, "key/expr", 100)
+    assert {:error, _} = Zenohex.Session.get(context.session_id, "key/expr", 100)
   end
 
   test "new_timestamp/1", context do
-    assert {:ok, zenoh_timestamp} = Zenohex.Session.new_timestamp(context.sessoin_id)
+    assert {:ok, zenoh_timestamp} = Zenohex.Session.new_timestamp(context.session_id)
     assert [timestamp, _zenoh_id_string] = String.split(zenoh_timestamp, "/")
     assert {:ok, %DateTime{}, 0} = DateTime.from_iso8601(timestamp)
   end
 
   test "info/1", context do
-    assert {:ok, %Zenohex.Session.Info{}} = Zenohex.Session.info(context.sessoin_id)
+    assert {:ok, %Zenohex.Session.Info{}} = Zenohex.Session.info(context.session_id)
   end
 
   test "declare_publisher/2", context do
     assert {:ok, _publisher_id} =
-             Zenohex.Session.declare_publisher(context.sessoin_id, "key/expr")
+             Zenohex.Session.declare_publisher(context.session_id, "key/expr")
   end
 
   test "declare_querier/2", context do
     assert {:ok, _querier_id} =
-             Zenohex.Session.declare_querier(context.sessoin_id, "key/expr")
+             Zenohex.Session.declare_querier(context.session_id, "key/expr")
   end
 end

--- a/test/zenohex/session_test.exs
+++ b/test/zenohex/session_test.exs
@@ -36,6 +36,20 @@ defmodule Zenohex.SessionTest do
     assert Zenohex.Session.delete(context.session_id, "key/expr") == :ok
   end
 
+  test "delete/3 accepts timestamp", context do
+    {:ok, subscriber_id} =
+      Zenohex.Session.declare_subscriber(context.session_id, "key/expr", self())
+
+    on_exit(fn -> Zenohex.Subscriber.undeclare(subscriber_id) end)
+
+    {:ok, timestamp} = Zenohex.Session.new_timestamp(context.session_id)
+
+    assert :ok =
+             Zenohex.Session.delete(context.session_id, "key/expr", timestamp: timestamp)
+
+    assert_receive %Zenohex.Sample{kind: :delete, key_expr: "key/expr", timestamp: ^timestamp}
+  end
+
   test "get/3", context do
     assert {:error, _} = Zenohex.Session.get(context.session_id, "key/expr", 100)
   end

--- a/test/zenohex_test.exs
+++ b/test/zenohex_test.exs
@@ -123,6 +123,19 @@ defmodule ZenohexTestModeCommon do
         #      which triggers Rust's `Drop`, so the callback is no longer called, and Query stop being sent.
         :ok = Zenohex.Queryable.undeclare(queryable_id)
       end
+
+      test "scout/3 convenience API", %{config: config} do
+        # NOTE: If there are multiple interfaces, each interface replies hello.
+        what =
+          case unquote(mode) do
+            "peer" -> :peer
+            "client" -> :router
+          end
+
+        assert {:ok, hellos} = Zenohex.scout(what, config, 100)
+
+        assert %Zenohex.Scouting.Hello{} = List.first(hellos)
+      end
     end
   end
 end
@@ -145,6 +158,13 @@ defmodule ZenohexTest do
   end
 
   describe "client mode with zenohd" do
+    # NOTE: These tests require `zenohd` to be running in `router` mode.
+    #       To start it:
+    #         git clone https://github.com/eclipse-zenoh/zenoh.git
+    #         cd zenoh
+    #         git checkout `the same Zenoh version used by zenohex`
+    #         # Update `DEFAULT_CONFIG.json5` to set `mode` to `router`.
+    #         cargo run -- --config DEFAULT_CONFIG.json5
     @describetag :skip
     ZenohexTestModeCommon.tests("client")
   end


### PR DESCRIPTION
#162 の `zenohex における zenoh 1.8.0 未対応項目リスト` の以下に対応しました。

## 1. 高優先度

| 区分 | zenoh 1.8.0 機能 | 安定性 |
|---|---|---|
| 関数/型 | `Session::declare_querier` / `Querier` / `QuerierBuilder` / `QuerierGetBuilder` | stable |
| オプション | `SessionGetBuilder::allowed_destination(Locality)` | stable |
| オプション | `SessionGetBuilder::accept_replies(ReplyKeyExpr)` | stable |
| オプション | `QueryableBuilder::allowed_origin(Locality)` | stable |
| オプション | `SubscriberBuilder::allowed_origin(Locality)` | stable |
| オプション | `PublisherBuilder::allowed_destination(Locality)` | stable |

## 2. 中優先度

| 区分 | zenoh 1.8.0 機能 | 安定性 |
|---|---|---|
| オプション | `LivelinessSubscriberBuilder::history(bool)` | stable |

## 3. 低優先度/方針次第

| 区分 | zenoh 1.8.0 機能 | 安定性 |
|---|---|---|
| 関数/型 | matching API（例: `Querier::matching_status`, `matching_listener`） | stable |

## 4. 要修正

| 区分 | 項目 | 安定性 |
|---|---|---|
| 実装不備 | `Session.delete` の `timestamp` オプション | stable |