### PR TITLE
feat: enhance caching for cargo in GHA workflows and change Windows runner to the latest

### DIFF
--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -36,6 +36,31 @@ jobs:
           restore-keys: |
             deps-${{ runner.os }}-${{ steps.setup-beam.outputs.otp-version }}-${{ steps.setup-beam.outputs.elixir-version }}-
 
+      - name: Cache compiled NIF
+        id: nif-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            priv/native
+          key: nif-${{ runner.os }}-${{ steps.setup-beam.outputs.otp-version }}-${{ hashFiles('native/zenohex_nif/Cargo.lock', 'native/zenohex_nif/Cargo.toml', 'native/zenohex_nif/rust-toolchain.toml', 'native/zenohex_nif/.cargo/**', 'native/zenohex_nif/src/**') }}
+
+      - name: Cache cargo target and registry
+        id: rust-cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            native/zenohex_nif -> target
+          cache-workspace-crates: "true"
+
+      - name: Show rust-cache status
+        run: 'echo "rust-cache hit: ${{ steps.rust-cache.outputs.cache-hit }}"'
+
+      - name: Show NIF cache status
+        run: 'echo "nif-cache hit: ${{ steps.nif-cache.outputs.cache-hit }}"'
+
+      - name: Export NIF build mode
+        run: echo "SKIP_ZENOHEX_NIF_BUILD=${{ steps.nif-cache.outputs.cache-hit }}" >> "$GITHUB_ENV"
+
       - name: Install deps
         if: steps.deps-cache.outputs.cache-hit != 'true'
         run: mix do deps.get, deps.compile
@@ -60,9 +85,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: priv/plts
-          key: plts-${{ runner.os }}-${{ steps.setup-beam.outputs.otp-version }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ hashFiles('**/*.lock') }}
+          key: plts-${{ runner.os }}-${{ env.MIX_ENV }}-${{ steps.setup-beam.outputs.otp-version }}-${{ steps.setup-beam.outputs.elixir-version }}-${{ hashFiles('**/mix.lock') }}
           restore-keys: |
-            plts-${{ runner.os }}-${{ steps.setup-beam.outputs.otp-version }}-${{ steps.setup-beam.outputs.elixir-version }}-
+            plts-${{ runner.os }}-${{ env.MIX_ENV }}-${{ steps.setup-beam.outputs.otp-version }}-${{ steps.setup-beam.outputs.elixir-version }}-
 
       - name: Build PLTs
         if: steps.plts-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -52,14 +52,8 @@ jobs:
             native/zenohex_nif -> target
           cache-workspace-crates: "true"
 
-      - name: Show rust-cache status
-        run: 'echo "rust-cache hit: ${{ steps.rust-cache.outputs.cache-hit }}"'
-
-      - name: Show NIF cache status
-        run: 'echo "nif-cache hit: ${{ steps.nif-cache.outputs.cache-hit }}"'
-
       - name: Export NIF build mode
-        run: echo "SKIP_ZENOHEX_NIF_BUILD=${{ steps.nif-cache.outputs.cache-hit }}" >> "$GITHUB_ENV"
+        run: echo "GHA_SKIP_ZENOHEX_NIF_BUILD=${{ steps.nif-cache.outputs.cache-hit }}" >> "$GITHUB_ENV"
 
       - name: Install deps
         if: steps.deps-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,12 +22,7 @@ jobs:
         os:
           - ubuntu-latest
           - macos-latest
-          # WHY: not using `latest`
-          #      Because we got a following error,
-          #      > Error: Tried to map a target OS from env. variable 'ImageOS' (got win25), but failed.
-          #      > If you're using a self-hosted runner, you should set 'env': 'ImageOS': ...
-          #      > to one of the following: ['ubuntu22', 'ubuntu24', 'win19', 'win22', 'macos13', 'macos14', 'macos15']
-          - windows-2022
+          - windows-latest
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,7 @@ jobs:
           cache-workspace-crates: "true"
 
       - name: Export NIF build mode
+        shell: bash
         run: echo "GHA_SKIP_ZENOHEX_NIF_BUILD=${{ steps.nif-cache.outputs.cache-hit }}" >> "$GITHUB_ENV"
 
       - name: Install deps

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,31 @@ jobs:
           restore-keys: |
             deps-${{ runner.os }}-${{ steps.setup-beam.outputs.otp-version }}-${{ steps.setup-beam.outputs.elixir-version }}-
 
+      - name: Cache compiled NIF
+        id: nif-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            priv/native
+          key: nif-${{ runner.os }}-${{ steps.setup-beam.outputs.otp-version }}-${{ hashFiles('native/zenohex_nif/Cargo.lock', 'native/zenohex_nif/Cargo.toml', 'native/zenohex_nif/rust-toolchain.toml', 'native/zenohex_nif/.cargo/**', 'native/zenohex_nif/src/**') }}
+
+      - name: Cache cargo target and registry
+        id: rust-cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            native/zenohex_nif -> target
+          cache-workspace-crates: "true"
+
+      - name: Show rust-cache status
+        run: 'echo "rust-cache hit: ${{ steps.rust-cache.outputs.cache-hit }}"'
+
+      - name: Show NIF cache status
+        run: 'echo "nif-cache hit: ${{ steps.nif-cache.outputs.cache-hit }}"'
+
+      - name: Export NIF build mode
+        run: echo "SKIP_ZENOHEX_NIF_BUILD=${{ steps.nif-cache.outputs.cache-hit }}" >> "$GITHUB_ENV"
+
       - name: Install deps
         if: steps.deps-cache.outputs.cache-hit != 'true'
         run: mix do deps.get, deps.compile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,14 +65,8 @@ jobs:
             native/zenohex_nif -> target
           cache-workspace-crates: "true"
 
-      - name: Show rust-cache status
-        run: 'echo "rust-cache hit: ${{ steps.rust-cache.outputs.cache-hit }}"'
-
-      - name: Show NIF cache status
-        run: 'echo "nif-cache hit: ${{ steps.nif-cache.outputs.cache-hit }}"'
-
       - name: Export NIF build mode
-        run: echo "SKIP_ZENOHEX_NIF_BUILD=${{ steps.nif-cache.outputs.cache-hit }}" >> "$GITHUB_ENV"
+        run: echo "GHA_SKIP_ZENOHEX_NIF_BUILD=${{ steps.nif-cache.outputs.cache-hit }}" >> "$GITHUB_ENV"
 
       - name: Install deps
         if: steps.deps-cache.outputs.cache-hit != 'true'

--- a/config/config.exs
+++ b/config/config.exs
@@ -2,4 +2,7 @@ import Config
 
 config :rustler_precompiled, :force_build, zenohex: true
 
+config :zenohex, Zenohex.Nif,
+  skip_compilation?: System.get_env("SKIP_ZENOHEX_NIF_BUILD") in ["1", "true"]
+
 import_config "#{config_env()}.exs"

--- a/config/config.exs
+++ b/config/config.exs
@@ -2,7 +2,9 @@ import Config
 
 config :rustler_precompiled, :force_build, zenohex: true
 
+# CI optimization for GitHub Actions workflows:
+# skip Rustler compilation during `mix compile` if a cached NIF has been restored.
 config :zenohex, Zenohex.Nif,
-  skip_compilation?: System.get_env("SKIP_ZENOHEX_NIF_BUILD") in ["1", "true"]
+  skip_compilation?: System.get_env("GHA_SKIP_ZENOHEX_NIF_BUILD") in ["1", "true"]
 
 import_config "#{config_env()}.exs"

--- a/config/config.exs
+++ b/config/config.exs
@@ -2,9 +2,4 @@ import Config
 
 config :rustler_precompiled, :force_build, zenohex: true
 
-# CI optimization for GitHub Actions workflows:
-# skip Rustler compilation during `mix compile` if a cached NIF has been restored.
-config :zenohex, Zenohex.Nif,
-  skip_compilation?: System.get_env("GHA_SKIP_ZENOHEX_NIF_BUILD") in ["1", "true"]
-
 import_config "#{config_env()}.exs"

--- a/lib/zenohex/nif.ex
+++ b/lib/zenohex/nif.ex
@@ -17,6 +17,9 @@ defmodule Zenohex.Nif do
     # NOTE: FROM HERE Rustler opts which are passed through to Rustler
     otp_app: :zenohex,
     crate: "zenohex_nif",
+    # CI optimization for GitHub Actions workflows:
+    # skip Rustler compilation during `mix compile` if a cached NIF has been restored.
+    skip_compilation?: System.get_env("GHA_SKIP_ZENOHEX_NIF_BUILD") in ["1", "true"],
     # NOTE: Uncomment during zenohhex_nif development.
     #       Setting `mode: :debug` makes `cargo build` skip the `--release` flag.
     # mode: :debug,


### PR DESCRIPTION
Rustler module (`priv/native/zenohex_nif.so`) をGHAでキャッシュできるようにしました！（たぶん,,, 
うまくいけば CI Test が改善されるはずです．
下記の検証は行っています（最終的に force push すればいいのでここで試してもらってよいです）

- lib/ native/ に変更がなければ直近ビルドのキャッシュを使う（.ex だけ再ビルドが走ることあるけどたいして長くないので気にしないことにしています）
- native/**/*.rs に変更があったら zenohex_nif.so のビルドが走る
- native/zenohex_nif/Cargo.lock に変更があったら crate download から走る（`cd native/zenohex_nif && cargo update` で検証）

やや気持ち悪いのは config/config.exs に修正を加えているところです．分かりやすい環境変数名にしてコメントを入れてありますが，これが許容できるかは議論の余地ありそうです．

---

追加で，Windows runner を latest に変更しました．これは erlef/setup-beam に起因していましたが，12月にリリース対応されたみたいです．
https://github.com/erlef/setup-beam/pull/388