### PR TITLE
Release v0.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ You can install this package into your project by adding `zenohex` to your list 
   defp deps do
     [
       ...
-      {:zenohex, "~> 0.8.0"},
+      {:zenohex, "~> 0.9.0"},
       ...
     ]
   end
@@ -130,7 +130,7 @@ When you want to build NIF module locally into your project, install Rustler by 
   defp deps do
     [
       ...
-      {:zenohex, "~> 0.8.0"},
+      {:zenohex, "~> 0.9.0"},
       {:rustler, ">= 0.0.0", optional: true},
       ...
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Zenohex.MixProject do
   use Mix.Project
 
-  @version "0.8.0"
+  @version "0.9.0"
   @source_url "https://github.com/biyooon-ex/zenohex"
 
   def project do

--- a/native/zenohex_nif/Cargo.lock
+++ b/native/zenohex_nif/Cargo.lock
@@ -4122,7 +4122,7 @@ dependencies = [
 
 [[package]]
 name = "zenohex_nif"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "log",
  "rustler",

--- a/native/zenohex_nif/Cargo.toml
+++ b/native/zenohex_nif/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zenohex_nif"
-version = "0.8.0"
+version = "0.9.0"
 authors = []
 edition = "2021"
 


### PR DESCRIPTION
**Currently, Zenohex uses version 1.9.0 of Zenoh.**

## :warning::warning: Breaking Change!! :warning::warning:

The function `Zenohex.Config.update_in/3` has been removed in v0.9.0.
For updating Zenoh configurations, please use `Zenohex.Config.insert_json5/3` instead.

### Migration method from `update_in/3`

```elixir
### Past usage with `update_in/3`:
Zenohex.Config.update_in(config, ["scouting", "delay"], fn _ -> 100 end)
### Use `insert_json5/3` with the key path joined by `/`:
Zenohex.Config.insert_json5(config, "scouting/delay", "100")
```
