### PR TITLE
Add automated release workflow to create a tag/release, precompile NIFs, download checksums,  and publish to Hex when the version numbers are updated

### DIFF
--- a/.github/workflows/nif_precompile.yml
+++ b/.github/workflows/nif_precompile.yml
@@ -1,9 +1,12 @@
 name: Build precompiled NIFs
 
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_call:
+    inputs:
+      tag:
+        description: "Release tag to upload artifacts to (e.g. v0.9.0)"
+        required: true
+        type: string
 
 jobs:
   build_release:

--- a/.github/workflows/nif_precompile.yml
+++ b/.github/workflows/nif_precompile.yml
@@ -62,8 +62,9 @@ jobs:
         path: ${{ steps.build-crate.outputs.file-path }}
 
     - name: Publish archives and packages
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       with:
+        tag_name: ${{ inputs.tag }}
         files: |
           ${{ steps.build-crate.outputs.file-path }}
-      if: startsWith(github.ref, 'refs/tags/')
+      if: inputs.tag != ''

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -31,14 +31,15 @@ jobs:
 
           current_mix_version=$(sed -n 's/^  @version "\(.*\)"/\1/p' mix.exs | head -n1)
           current_cargo_version=$(sed -n 's/^version = "\(.*\)"/\1/p' native/zenohex_nif/Cargo.toml | head -n1)
+          current_lock_version=$(grep -A1 '^name = "zenohex_nif"' native/zenohex_nif/Cargo.lock | sed -n 's/^version = "\(.*\)"/\1/p')
 
-          if [[ -z "$current_mix_version" || -z "$current_cargo_version" ]]; then
-            echo "Failed to detect version from mix.exs or Cargo.toml"
+          if [[ -z "$current_mix_version" || -z "$current_cargo_version" || -z "$current_lock_version" ]]; then
+            echo "Failed to detect version from mix.exs, Cargo.toml, or Cargo.lock"
             exit 1
           fi
 
-          if [[ "$current_mix_version" != "$current_cargo_version" ]]; then
-            echo "Version mismatch: mix.exs=$current_mix_version, Cargo.toml=$current_cargo_version"
+          if [[ "$current_mix_version" != "$current_cargo_version" || "$current_mix_version" != "$current_lock_version" ]]; then
+            echo "Version mismatch: mix.exs=$current_mix_version, Cargo.toml=$current_cargo_version, Cargo.lock=$current_lock_version"
             exit 1
           fi
 

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -3,7 +3,7 @@ name: Automated Release
 on:
   push:
     branches:
-      - main
+      - release_automation
     paths:
       - mix.exs
       - native/zenohex_nif/Cargo.toml
@@ -43,25 +43,14 @@ jobs:
             exit 1
           fi
 
-          previous_sha="${{ github.event.before }}"
-          if [[ -n "$previous_sha" && "$previous_sha" != "0000000000000000000000000000000000000000" ]] && \
-             git show "${previous_sha}":mix.exs >/tmp/prev_mix.exs 2>/dev/null; then
-            previous_mix_version=$(sed -n 's/^  @version "\(.*\)"/\1/p' /tmp/prev_mix.exs | head -n1)
-          else
-            previous_mix_version=""
-          fi
-
           tag="v${current_mix_version}"
 
           if git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null 2>&1; then
             echo "Tag ${tag} already exists. Skipping release automation."
             echo "release_needed=false" >> "$GITHUB_OUTPUT"
-          elif [[ "$current_mix_version" != "$previous_mix_version" ]]; then
-            echo "Detected version bump: ${previous_mix_version} -> ${current_mix_version}"
-            echo "release_needed=true" >> "$GITHUB_OUTPUT"
           else
-            echo "Version unchanged (${current_mix_version}). Skipping release automation."
-            echo "release_needed=false" >> "$GITHUB_OUTPUT"
+            echo "Versions are aligned and tag ${tag} does not exist. Proceeding with release automation."
+            echo "release_needed=true" >> "$GITHUB_OUTPUT"
           fi
 
           echo "version=${current_mix_version}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -3,7 +3,7 @@ name: Automated Release
 on:
   push:
     branches:
-      - release_automation
+      - main
     paths:
       - mix.exs
       - native/zenohex_nif/Cargo.toml

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -1,0 +1,139 @@
+name: Automated Release
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - mix.exs
+      - native/zenohex_nif/Cargo.toml
+  workflow_dispatch:
+
+jobs:
+  detect-version-bump:
+    runs-on: ubuntu-latest
+    outputs:
+      release_needed: ${{ steps.detect.outputs.release_needed }}
+      version: ${{ steps.detect.outputs.version }}
+      tag: ${{ steps.detect.outputs.tag }}
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Detect version bump
+        id: detect
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          current_mix_version=$(sed -n 's/^  @version "\(.*\)"/\1/p' mix.exs | head -n1)
+          current_cargo_version=$(sed -n 's/^version = "\(.*\)"/\1/p' native/zenohex_nif/Cargo.toml | head -n1)
+
+          if [[ -z "$current_mix_version" || -z "$current_cargo_version" ]]; then
+            echo "Failed to detect version from mix.exs or Cargo.toml"
+            exit 1
+          fi
+
+          if [[ "$current_mix_version" != "$current_cargo_version" ]]; then
+            echo "Version mismatch: mix.exs=$current_mix_version, Cargo.toml=$current_cargo_version"
+            exit 1
+          fi
+
+          if git show HEAD~1:mix.exs >/tmp/prev_mix.exs 2>/dev/null; then
+            previous_mix_version=$(sed -n 's/^  @version "\(.*\)"/\1/p' /tmp/prev_mix.exs | head -n1)
+          else
+            previous_mix_version=""
+          fi
+
+          tag="v${current_mix_version}"
+
+          if git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null 2>&1; then
+            echo "Tag ${tag} already exists. Skipping release automation."
+            echo "release_needed=false" >> "$GITHUB_OUTPUT"
+          elif [[ "$current_mix_version" != "$previous_mix_version" ]]; then
+            echo "Detected version bump: ${previous_mix_version} -> ${current_mix_version}"
+            echo "release_needed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Version unchanged (${current_mix_version}). Skipping release automation."
+            echo "release_needed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          echo "version=${current_mix_version}" >> "$GITHUB_OUTPUT"
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+
+  create-tag-and-release:
+    needs: detect-version-bump
+    if: needs.detect-version-bump.outputs.release_needed == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Create tag and GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ needs.detect-version-bump.outputs.tag }}
+          name: ${{ needs.detect-version-bump.outputs.tag }}
+          generate_release_notes: true
+
+  build-precompiled-nifs:
+    needs:
+      - detect-version-bump
+      - create-tag-and-release
+    if: needs.detect-version-bump.outputs.release_needed == 'true'
+    uses: ./.github/workflows/nif_precompile.yml
+    permissions:
+      contents: write
+    with:
+      tag: ${{ needs.detect-version-bump.outputs.tag }}
+    secrets: inherit
+
+  update-checksum-and-publish-hex:
+    needs:
+      - detect-version-bump
+      - build-precompiled-nifs
+    if: needs.detect-version-bump.outputs.release_needed == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    env:
+      OTP_VERSION: 27.3.4.2
+      ELIXIR_VERSION: 1.18.4
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Erlang/Elixir
+        uses: erlef/setup-beam@v1
+        with:
+          otp-version: ${{ env.OTP_VERSION }}
+          elixir-version: ${{ env.ELIXIR_VERSION }}
+
+      - name: Install dependencies
+        run: mix deps.get
+
+      - name: Download all precompiled NIF checksums
+        run: mix rustler_precompiled.download Zenohex.Nif --all
+
+      - name: Commit checksum update
+        shell: bash
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add checksum-Elixir.Zenohex.Nif.exs
+
+          if git diff --cached --quiet; then
+            echo "No checksum changes to commit"
+          else
+            git commit -m "chore(release): update NIF checksums for ${{ needs.detect-version-bump.outputs.tag }}"
+            git push
+          fi
+
+      - name: Publish to Hex
+        env:
+          HEX_API_KEY: ${{ secrets['HEX_API_KEY'] }}
+        run: mix hex.publish --yes

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -70,11 +70,29 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+
+      - name: Extract Zenoh version info from README
+        id: zenoh-info
+        shell: bash
+        run: |
+          zenoh_info=$(sed -n '/^\*\*Currently, Zenohex uses version.*\*\*$/p' README.md)
+          # Escape for use in github output
+          {
+            echo "content<<EOF"
+            echo "$zenoh_info"
+            echo ""
+            echo "We recommend using the same Zenoh version for communication compatibility."
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Create tag and GitHub release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.detect-version-bump.outputs.tag }}
           name: ${{ needs.detect-version-bump.outputs.tag }}
+          body: ${{ steps.zenoh-info.outputs.content }}
           generate_release_notes: true
 
   build-precompiled-nifs:
@@ -135,5 +153,5 @@ jobs:
 
       - name: Publish to Hex
         env:
-          HEX_API_KEY: ${{ secrets['HEX_API_KEY'] }}
+          HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
         run: mix hex.publish --yes

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - mix.exs
       - native/zenohex_nif/Cargo.toml
+      - native/zenohex_nif/Cargo.lock
   workflow_dispatch:
 
 jobs:
@@ -20,7 +21,7 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: Detect version bump
         id: detect
@@ -41,7 +42,9 @@ jobs:
             exit 1
           fi
 
-          if git show HEAD~1:mix.exs >/tmp/prev_mix.exs 2>/dev/null; then
+          previous_sha="${{ github.event.before }}"
+          if [[ -n "$previous_sha" && "$previous_sha" != "0000000000000000000000000000000000000000" ]] && \
+             git show "${previous_sha}":mix.exs >/tmp/prev_mix.exs 2>/dev/null; then
             previous_mix_version=$(sed -n 's/^  @version "\(.*\)"/\1/p' /tmp/prev_mix.exs | head -n1)
           else
             previous_mix_version=""
@@ -105,7 +108,6 @@ jobs:
       contents: write
     with:
       tag: ${{ needs.detect-version-bump.outputs.tag }}
-    secrets: inherit
 
   update-checksum-and-publish-hex:
     needs:

--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ Therefore, we clearly specify these version numbers with `==` in mix.exs and `=`
 
 ### How to release
 
+We expect [release-automation.yml](.github/workflows/release-automation.yml) to automatically trigger the following workflow when the version numbers in `mix.exs`, `Cargo.toml`, and `Cargo.lock` are updated and pushed to main branch; if that doesn’t happen, operate the following steps manually.
+
 These steps just follow the [Recommended flow of rustler_precompiled](https://hexdocs.pm/rustler_precompiled/precompilation_guide.html#recommended-flow).
 
 1. Change versions, `mix.exs`, `native/zenohex_nif/Cargo.toml`


### PR DESCRIPTION
名前のとおりで下記の Release 作業を自動化しました．
https://github.com/biyooon-ex/zenohex/tree/release_automation?tab=readme-ov-file#how-to-release

mix.exs, Cargo.toml, Cargo.lock のバージョン番号が揃いで bump されて，それがまだ存在しない番号のときに triger されていきます．いちお動作確認したので大丈夫だと思っていますが，次のリリースが待ち遠しい,,, 