### PR TITLE
Add KeyExpr join/2 and change autocanonize/1 api

### DIFF
--- a/lib/zenohex/key_expr.ex
+++ b/lib/zenohex/key_expr.ex
@@ -8,8 +8,13 @@ defmodule Zenohex.KeyExpr do
 
   @doc """
   Canonizes the `key_expr`.
+
+  ## Examples
+
+      iex> Zenohex.KeyExpr.canonize("key/expr/**/*")
+      {:ok, "key/expr/*/**"}
   """
-  @spec canonize(String.t()) :: String.t()
+  @spec canonize(String.t()) :: {:ok, String.t()} | {:error, String.t()}
   defdelegate canonize(key_expr),
     to: Zenohex.Nif,
     as: :keyexpr_autocanonize
@@ -41,4 +46,19 @@ defmodule Zenohex.KeyExpr do
   defdelegate includes?(key_expr1, key_expr2),
     to: Zenohex.Nif,
     as: :keyexpr_includes?
+
+  @doc """
+  Joins two key expressions, inserting a `/` between them.
+
+  Returns the resulting key expression string, canonized.
+
+  ## Examples
+
+      iex> Zenohex.KeyExpr.join("key/expr", "sub")
+      {:ok, "key/expr/sub"}
+  """
+  @spec join(String.t(), String.t()) :: {:ok, String.t()} | {:error, String.t()}
+  defdelegate join(key_expr1, key_expr2),
+    to: Zenohex.Nif,
+    as: :keyexpr_join
 end

--- a/lib/zenohex/nif.ex
+++ b/lib/zenohex/nif.ex
@@ -147,7 +147,7 @@ defmodule Zenohex.Nif do
   # @spec keyexpr_undeclare(id(), key_expr :: reference()) :: :ok | {:error, term()}
   # def keyexpr_undeclare(_session_id, _key_expr), do: err()
 
-  @spec keyexpr_autocanonize(String.t()) :: String.t()
+  @spec keyexpr_autocanonize(String.t()) :: {:ok, String.t()} | {:error, String.t()}
   def keyexpr_autocanonize(_key_expr), do: err()
 
   @spec keyexpr_valid?(String.t()) :: boolean()
@@ -158,6 +158,9 @@ defmodule Zenohex.Nif do
 
   @spec keyexpr_includes?(String.t(), String.t()) :: boolean()
   def keyexpr_includes?(_key_expr1, _keyexpr2), do: err()
+
+  @spec keyexpr_join(String.t(), String.t()) :: {:ok, String.t()} | {:error, String.t()}
+  def keyexpr_join(_key_expr1, _key_expr2), do: err()
 
   # Liveliness
 

--- a/native/zenohex_nif/src/keyexpr.rs
+++ b/native/zenohex_nif/src/keyexpr.rs
@@ -1,12 +1,9 @@
 #[rustler::nif]
-fn keyexpr_autocanonize(key_expr: String) -> rustler::NifResult<String> {
-    match zenoh::key_expr::keyexpr::autocanonize(&mut key_expr.clone()) {
-        Ok(key_expr) => Ok(key_expr.to_string()),
-        Err(error) => Err(rustler::Error::RaiseTerm(Box::new(
-            crate::helper::exception::ArgumentError {
-                message: error.to_string(),
-            },
-        ))),
+fn keyexpr_autocanonize(key_expr: String) -> rustler::NifResult<(rustler::Atom, String)> {
+    let mut key_expr = key_expr;
+    match zenoh::key_expr::keyexpr::autocanonize(&mut key_expr) {
+        Ok(key_expr) => Ok((rustler::types::atom::ok(), key_expr.to_string())),
+        Err(error) => Err(rustler::Error::Term(crate::zenoh_error!(error))),
     }
 }
 
@@ -35,6 +32,15 @@ fn keyexpr_includes(key_expr1: &str, key_expr2: &str) -> rustler::NifResult<bool
     let key_expr2 = new(key_expr2)?;
 
     Ok(key_expr1.includes(key_expr2))
+}
+
+#[rustler::nif]
+fn keyexpr_join(key_expr1: &str, key_expr2: &str) -> rustler::NifResult<(rustler::Atom, String)> {
+    let ke1 = zenoh::key_expr::keyexpr::new(key_expr1)
+        .map_err(|error| rustler::Error::Term(crate::zenoh_error!(error)))?;
+    ke1.join(key_expr2)
+        .map(|ke| (rustler::types::atom::ok(), ke.to_string()))
+        .map_err(|error| rustler::Error::Term(crate::zenoh_error!(error)))
 }
 
 fn new(key_expr: &str) -> rustler::NifResult<&zenoh::key_expr::keyexpr> {

--- a/test/zenohex/key_expr_test.exs
+++ b/test/zenohex/key_expr_test.exs
@@ -2,8 +2,8 @@ defmodule Zenohex.KeyExprTest do
   use ExUnit.Case
 
   test "canonize/1" do
-    assert Zenohex.KeyExpr.canonize("key/expr/**/*") == "key/expr/*/**"
-    assert_raise ArgumentError, fn -> Zenohex.KeyExpr.canonize("invalid/key/expr?") end
+    assert {:ok, "key/expr/*/**"} == Zenohex.KeyExpr.canonize("key/expr/**/*")
+    assert {:error, _} = Zenohex.KeyExpr.canonize("invalid/key/expr?")
   end
 
   test "valid?/1" do
@@ -26,5 +26,14 @@ defmodule Zenohex.KeyExprTest do
     assert_raise ArgumentError, fn ->
       Zenohex.KeyExpr.includes?("valid/key/expr", "invalid/key/expr?")
     end
+  end
+
+  test "join/2" do
+    assert {:ok, "key/expr/sub"} = Zenohex.KeyExpr.join("key/expr", "sub")
+    assert {:error, _} = Zenohex.KeyExpr.join("invalid/key/expr?", "sub")
+  end
+
+  test "join/2 returns canonized key expression" do
+    assert {:ok, "key/expr/*/**"} == Zenohex.KeyExpr.join("key/expr/**", "*")
   end
 end


### PR DESCRIPTION
以下を行いました。

- KeyExpr.join/2 を追加
- KeyExpr.autocanonize/1 を ok/error タプルを返すように変更

---

@takasehideki `autocanonize/1` は breaking change ですが、エイッとやってしまいました。