### PR TITLE
Fix typos in documentation examples

### DIFF
--- a/lib/zenohex/examples/publisher.ex
+++ b/lib/zenohex/examples/publisher.ex
@@ -39,7 +39,7 @@ defmodule Zenohex.Examples.Publisher do
 
     - `args` – a keyword list that can include the following keys:
       - `:session_id` – the ID of the session
-      - `:key_expr` – the key expression to subscribe to
+      - `:key_expr` – the key expression to publish to
   """
   @spec start_link([
           {:session_id, Zenohex.Session.id()}

--- a/lib/zenohex/examples/subscriber.ex
+++ b/lib/zenohex/examples/subscriber.ex
@@ -11,7 +11,7 @@ defmodule Zenohex.Examples.Subscriber do
 
   ## Examples
 
-      iex> Zenohex.Examples.Queryable.start_link([])
+      iex> Zenohex.Examples.Subscriber.start_link([])
   """
 
   use GenServer

--- a/lib/zenohex/key_expr.ex
+++ b/lib/zenohex/key_expr.ex
@@ -25,7 +25,7 @@ defmodule Zenohex.KeyExpr do
   @doc """
   Returns true if the keyexprs intersect.
 
-  There exists at least one key which is contained in both of the sets defined by `keyr_expr1` and `key_expr2`.
+  There exists at least one key which is contained in both of the sets defined by `key_expr1` and `key_expr2`.
   """
   @spec intersects?(String.t(), String.t()) :: boolean()
   defdelegate intersects?(key_expr1, key_expr2),

--- a/lib/zenohex/query.ex
+++ b/lib/zenohex/query.ex
@@ -107,7 +107,7 @@ defmodule Zenohex.Query do
     as: :query_reply_error
 
   @doc """
-  Sends an delete reply to the given Zenoh query.
+  Sends a delete reply to the given Zenoh query.
 
   ## Options
 


### PR DESCRIPTION
lib/zenohex/examples/subscriber.ex の moduledoc が Queryable -> Subscriber になっていたので,,, 他もちょっと見直して修正しました．コードには影響ないのでこのままマージします．