### PR TITLE
Update dependabot.yml to follow gha update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,8 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 10
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10


### PR DESCRIPTION
この追加により例えば、

https://github.com/biyooon-ex/zenohex/blob/2b13430405ba8e8b2d147d4b64ad41f67d6dc072/.github/workflows/test.yml#L28

の `v4` がアップデートされた場合に dependabot で PR が届くようになります。