### PR TITLE
refactor: specifiy fixed OS versions for GitHub Actions

### DIFF
--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   code-analysis:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/nif_precompile.yml
+++ b/.github/workflows/nif_precompile.yml
@@ -19,15 +19,15 @@ jobs:
       matrix:
         nif: ["2.15"]
         job:
-          - { target: aarch64-apple-darwin        , os: macos-latest   }
-          - { target: aarch64-unknown-linux-gnu   , os: ubuntu-latest , use-cross: true }
-          - { target: aarch64-unknown-linux-musl  , os: ubuntu-latest , use-cross: true }
-          - { target: arm-unknown-linux-gnueabihf , os: ubuntu-latest , use-cross: true }
-          - { target: x86_64-apple-darwin         , os: macos-latest   }
-          - { target: x86_64-pc-windows-gnu       , os: windows-latest }
-          - { target: x86_64-pc-windows-msvc      , os: windows-latest }
-          - { target: x86_64-unknown-linux-gnu    , os: ubuntu-latest  }
-          - { target: x86_64-unknown-linux-musl   , os: ubuntu-latest , use-cross: true }
+          - { target: aarch64-apple-darwin        , os: macos-26 }
+          - { target: aarch64-unknown-linux-gnu   , os: ubuntu-24.04 , use-cross: true }
+          - { target: aarch64-unknown-linux-musl  , os: ubuntu-24.04 , use-cross: true }
+          - { target: arm-unknown-linux-gnueabihf , os: ubuntu-24.04 , use-cross: true }
+          - { target: x86_64-apple-darwin         , os: macos-26-intel }
+          - { target: x86_64-pc-windows-gnu       , os: windows-2025 }
+          - { target: x86_64-pc-windows-msvc      , os: windows-2025 }
+          - { target: x86_64-unknown-linux-gnu    , os: ubuntu-24.04 }
+          - { target: x86_64-unknown-linux-musl   , os: ubuntu-24.04 , use-cross: true }
 
     steps:
     - name: Checkout source code

--- a/.github/workflows/nif_precompile.yml
+++ b/.github/workflows/nif_precompile.yml
@@ -19,13 +19,14 @@ jobs:
       matrix:
         nif: ["2.15"]
         job:
+          # WHY: not using `-latest` to `os:`, see https://github.com/biyooon-ex/zenohex/pull/196
           - { target: aarch64-apple-darwin        , os: macos-26 }
           - { target: aarch64-unknown-linux-gnu   , os: ubuntu-24.04 , use-cross: true }
           - { target: aarch64-unknown-linux-musl  , os: ubuntu-24.04 , use-cross: true }
           - { target: arm-unknown-linux-gnueabihf , os: ubuntu-24.04 , use-cross: true }
           - { target: x86_64-apple-darwin         , os: macos-26-intel }
-          - { target: x86_64-pc-windows-gnu       , os: windows-2025 }
-          - { target: x86_64-pc-windows-msvc      , os: windows-2025 }
+          - { target: x86_64-pc-windows-gnu       , os: windows-2022 }
+          - { target: x86_64-pc-windows-msvc      , os: windows-2022 }
           - { target: x86_64-unknown-linux-gnu    , os: ubuntu-24.04 }
           - { target: x86_64-unknown-linux-musl   , os: ubuntu-24.04 , use-cross: true }
 

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   detect-version-bump:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       release_needed: ${{ steps.detect.outputs.release_needed }}
       version: ${{ steps.detect.outputs.version }}
@@ -59,7 +59,7 @@ jobs:
   create-tag-and-release:
     needs: detect-version-bump
     if: needs.detect-version-bump.outputs.release_needed == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     steps:
@@ -104,7 +104,7 @@ jobs:
       - detect-version-bump
       - build-precompiled-nifs
     if: needs.detect-version-bump.outputs.release_needed == 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: write
     env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,9 +20,10 @@ jobs:
       fail-fast: false
       matrix:
         os:
+          # WHY: not using `-latest` to `os:`, see https://github.com/biyooon-ex/zenohex/pull/196
           - ubuntu-24.04
           - macos-26
-          - windows-2025
+          - windows-2022
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,9 +20,9 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
+          - ubuntu-24.04
+          - macos-26
+          - windows-2025
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
GHA の OS image で `windows-latest` -> `windows-2025-vs2026` になっていろいろ不都合そうなことへの対応です．

もともとの原因であった setup-beam ではすでに PR 提出済みのようでした．
https://github.com/erlef/setup-beam/pull/461

しかしながら，じきにすぐ `ubuntu-26.04` も出てくるでしょうし，これらに引っ張られて対応するのもややこしくなると思いまして，いっそのことすべての OS でバージョンを明示指定することにしました．以前は `-latest` のほうがいいと考えていましたが路線変更ということです．
指定したバージョンはここの `-latest` を参照しています．
https://github.com/actions/runner-images#available-images