### PR TITLE
bump minimum Elixir version to 1.18 (due to usage of standand JSON module

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Zenohex.MixProject do
     [
       app: :zenohex,
       version: @version,
-      elixir: "~> 1.15",
+      elixir: "~> 1.18",
       description: "Zenoh client library for elixir.",
       package: package(),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
Zenoh Config API の対応 #174 #181 で Erlang の `:json` を用いていますが，これは Erlang/OTP 27 から標準モジュールになったようです．
https://www.erlang.org/blog/highlights-otp-27/#the-new-json-module

Elixir では v1.18 から Built-in JSON が導入されています（要するに上記のラッパと認識しています）
https://elixir-lang.org/blog/2024/12/19/elixir-v1-18-0-released/

#181 はまだやりかけですが，せっかくなら Elixir の `JSON` に変更するつもりでいます．Elixir v1.17 以前もサポートするには Jason を使う手もありますがあまりモチベーションが湧きません．

以上のことから Elixir v1.18+ を必須にしたいと考えています．
@pojiro いかがでしょか？？