### PR TITLE
refactor: Add ignore rule for dtolnay/rust-toolchain because Zenoh should be used with Rust 1.93.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,5 @@ updates:
     schedule:
       interval: daily
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "dtolnay/rust-toolchain"


### PR DESCRIPTION
#191 で dependabot が Rust (dtolnay/rust-toolchain) をアップデートしようとしていますが，これは Zenoh 的に都合よろしくないので ignore list として追加しました．
https://github.com/eclipse-zenoh/zenoh/blob/main/rust-toolchain.toml