### PR TITLE
fix: improve session close handling to ignore timeout errors during cleanup

### DIFF
--- a/native/zenohex_nif/src/session.rs
+++ b/native/zenohex_nif/src/session.rs
@@ -273,13 +273,28 @@ fn session_close(
     session_id_resource: rustler::ResourceArc<SessionIdResource>,
 ) -> rustler::NifResult<rustler::Atom> {
     let session_id = &session_id_resource;
-    let session = SessionMap::remove_session(&SESSION_MAP, session_id)?;
+
+    let session = SessionMap::get_session(&SESSION_MAP, session_id)?;
     let session_locked = session.read().unwrap();
 
-    session_locked
-        .close()
-        .wait()
-        .map_err(|error| rustler::Error::Term(crate::zenoh_error!(error)))?;
+    match session_locked.close().wait() {
+        Ok(_) => {}
+        Err(error) => {
+            let error_string = error.to_string();
+
+            // Windows CI intermittently times out during close even though
+            // this is only teardown. Treat that case as successful cleanup.
+            if !error_string.contains("close operation timed out") {
+                return Err(rustler::Error::Term(Box::new(error_string)));
+            }
+
+            log::warn!("ignoring session close timeout during cleanup: {}", error_string);
+        }
+    }
+
+    drop(session_locked);
+
+    let _ = SessionMap::remove_session(&SESSION_MAP, session_id);
 
     Ok(rustler::types::atom::ok())
 }

--- a/native/zenohex_nif/src/session.rs
+++ b/native/zenohex_nif/src/session.rs
@@ -141,6 +141,10 @@ impl<'a> SessionMap<'_> {
 
 pub static SESSION_MAP: LazyLock<SessionMap> = LazyLock::new(SessionMap::new);
 
+// NOTE: Zenoh close timeout detection currently relies on message text.
+// Keep this as a single constant so it is easy to audit/update when upgrading Zenoh.
+const CLOSE_TIMEOUT_MESSAGE: &str = "close operation timed out";
+
 enum SessionCloseStatus {
     AlreadyClosed,
     Closed,
@@ -149,6 +153,8 @@ enum SessionCloseStatus {
 
 // WHY: Keep close behavior consistent between explicit close and resource drop,
 //      including timeout-tolerant cleanup on Windows.
+// PRECONDITION: Caller must remove the session from SESSION_MAP before invoking this
+//               helper if timeout is treated as successful cleanup.
 fn close_session_tolerating_timeout(
     session: &Session<'_>,
     context: &str,
@@ -165,7 +171,7 @@ fn close_session_tolerating_timeout(
             // Closing a session can intermittently time out during cleanup, especially on
             // Windows CI. The session has already been removed from SESSION_MAP, so treat
             // that timeout as a successful close and avoid failing teardown.
-            if error_string.contains("close operation timed out") {
+            if error_string.contains(CLOSE_TIMEOUT_MESSAGE) {
                 log::warn!(
                     "ignoring session close timeout during {}: {}",
                     context,

--- a/native/zenohex_nif/src/session.rs
+++ b/native/zenohex_nif/src/session.rs
@@ -141,6 +141,44 @@ impl<'a> SessionMap<'_> {
 
 pub static SESSION_MAP: LazyLock<SessionMap> = LazyLock::new(SessionMap::new);
 
+enum SessionCloseStatus {
+    AlreadyClosed,
+    Closed,
+    TimedOutIgnored,
+}
+
+// WHY: Keep close behavior consistent between explicit close and resource drop,
+//      including timeout-tolerant cleanup on Windows.
+fn close_session_tolerating_timeout(
+    session: &Session<'_>,
+    context: &str,
+) -> rustler::NifResult<SessionCloseStatus> {
+    if session.is_closed() {
+        return Ok(SessionCloseStatus::AlreadyClosed);
+    }
+
+    match session.close().wait() {
+        Ok(_) => Ok(SessionCloseStatus::Closed),
+        Err(error) => {
+            let error_string = error.to_string();
+
+            // Closing a session can intermittently time out during cleanup, especially on
+            // Windows CI. The session has already been removed from SESSION_MAP, so treat
+            // that timeout as a successful close and avoid failing teardown.
+            if error_string.contains("close operation timed out") {
+                log::warn!(
+                    "ignoring session close timeout during {}: {}",
+                    context,
+                    error_string
+                );
+                Ok(SessionCloseStatus::TimedOutIgnored)
+            } else {
+                Err(rustler::Error::Term(crate::zenoh_error!(error)))
+            }
+        }
+    }
+}
+
 // WHY: Use zenoh::session::ZenohId for resource, instead of zenoh::Session itself
 //      If we use the session for resource, we got the following error.
 //      the trait std::panic::RefUnwindSafe is not implemented for
@@ -165,12 +203,18 @@ impl Drop for SessionIdResource {
         match SessionMap::remove_session(&SESSION_MAP, session_id) {
             Ok(session) => {
                 let session_locked = session.read().unwrap();
-                let message = if session_locked.is_closed() {
-                    "session already closed"
-                } else {
-                    session_locked.close().wait().unwrap();
-                    "session closed by drop"
-                };
+                let message =
+                    match close_session_tolerating_timeout(&session_locked, "drop cleanup") {
+                        Ok(SessionCloseStatus::AlreadyClosed) => "session already closed",
+                        Ok(SessionCloseStatus::Closed) => "session closed by drop",
+                        Ok(SessionCloseStatus::TimedOutIgnored) => {
+                            "session close timeout ignored by drop"
+                        }
+                        Err(error) => {
+                            log::warn!("session close failed during drop cleanup: {:?}", error);
+                            return;
+                        }
+                    };
                 log::debug!("{}", message)
             }
             Err(_error) => log::debug!("session already removed"),
@@ -268,34 +312,20 @@ fn session_open(
     ))
 }
 
-#[rustler::nif]
+// WHY: close().wait() can block until timeout, so run this NIF on DirtyIo.
+#[rustler::nif(schedule = "DirtyIo")]
 fn session_close(
     session_id_resource: rustler::ResourceArc<SessionIdResource>,
 ) -> rustler::NifResult<rustler::Atom> {
     let session_id = &session_id_resource;
 
+    // Remove first so concurrent operations fail fast while close is in progress.
     let session = SessionMap::remove_session(&SESSION_MAP, session_id)?;
     let session_locked = session.read().unwrap();
 
-    match session_locked.close().wait() {
-        Ok(_) => Ok(rustler::types::atom::ok()),
-        Err(error) => {
-            let error_string = error.to_string();
+    close_session_tolerating_timeout(&session_locked, "session_close")?;
 
-            // Closing a session can intermittently time out during cleanup, especially on
-            // Windows CI. The session has already been removed from SESSION_MAP, so treat
-            // that timeout as a successful close and avoid failing teardown.
-            if error_string.contains("close operation timed out") {
-                log::warn!(
-                    "ignoring session close timeout during cleanup: {}",
-                    error_string
-                );
-                Ok(rustler::types::atom::ok())
-            } else {
-                Err(rustler::Error::Term(crate::zenoh_error!(error)))
-            }
-        }
-    }
+    Ok(rustler::types::atom::ok())
 }
 
 #[rustler::nif]

--- a/native/zenohex_nif/src/session.rs
+++ b/native/zenohex_nif/src/session.rs
@@ -274,29 +274,28 @@ fn session_close(
 ) -> rustler::NifResult<rustler::Atom> {
     let session_id = &session_id_resource;
 
-    let session = SessionMap::get_session(&SESSION_MAP, session_id)?;
+    let session = SessionMap::remove_session(&SESSION_MAP, session_id)?;
     let session_locked = session.read().unwrap();
 
     match session_locked.close().wait() {
-        Ok(_) => {}
+        Ok(_) => Ok(rustler::types::atom::ok()),
         Err(error) => {
             let error_string = error.to_string();
 
-            // Windows CI intermittently times out during close even though
-            // this is only teardown. Treat that case as successful cleanup.
-            if !error_string.contains("close operation timed out") {
-                return Err(rustler::Error::Term(Box::new(error_string)));
+            // Closing a session can intermittently time out during cleanup, especially on
+            // Windows CI. The session has already been removed from SESSION_MAP, so treat
+            // that timeout as a successful close and avoid failing teardown.
+            if error_string.contains("close operation timed out") {
+                log::warn!(
+                    "ignoring session close timeout during cleanup: {}",
+                    error_string
+                );
+                Ok(rustler::types::atom::ok())
+            } else {
+                Err(rustler::Error::Term(crate::zenoh_error!(error)))
             }
-
-            log::warn!("ignoring session close timeout during cleanup: {}", error_string);
         }
     }
-
-    drop(session_locked);
-
-    let _ = SessionMap::remove_session(&SESSION_MAP, session_id);
-
-    Ok(rustler::types::atom::ok())
 }
 
 #[rustler::nif]


### PR DESCRIPTION
`windows-2022` にした影響もなくはないと思いますが，GHA CI の Windows での flaky 具合が増しているようです．
パイセンはこうするのがよいといっており，確かに妥当ではあるかなと思った次第です（URL先が見られるか怪しいのであとでスレッドにも貼り付けます）
https://github.com/copilot/c/1cdee38a-3292-44dc-9610-9d1692113603