### PR TITLE
test: remove explicit close in open tests (revert 11d3cc4) and add retry to Windows CI to improve flaky tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,9 +80,9 @@ jobs:
       #      while we investigate the root cause separately.
       - name: Run tests with retry (Windows)
         if: runner.os == 'Windows'
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@v4
         with:
-          timeout_minutes: 30
+          timeout_seconds: 30
           max_attempts: 2
           retry_wait_seconds: 10
           command: mix test --warnings-as-errors --cover

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,5 +72,17 @@ jobs:
       - name: Compile project
         run: mix compile --warnings-as-errors
 
-      - name: Run tests
+      - name: Run tests (Linux/macOS)
+        if: runner.os != 'Windows'
         run: mix test --warnings-as-errors --cover
+
+      # WHY: Keep the flaky Windows close timeout from failing the whole job
+      #      while we investigate the root cause separately.
+      - name: Run tests with retry (Windows)
+        if: runner.os == 'Windows'
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 30
+          max_attempts: 2
+          retry_wait_seconds: 10
+          command: mix test --warnings-as-errors --cover

--- a/test/zenohex/session_test.exs
+++ b/test/zenohex/session_test.exs
@@ -13,32 +13,14 @@ defmodule Zenohex.SessionTest do
   end
 
   test "open/0" do
-    assert {:ok, session_id} = Zenohex.Session.open()
-
-    # Use explicit cleanup here because relying on Drop was flaky on Windows CI.
-    # Without this, Windows CI intermittently failed with the following error:
-    #
-    #   ** (MatchError) no match of right hand side value:
-    #   {:error,
-    #    "native/zenohex_nif/src\\session.rs:282: close operation timed out! at
-    #    C:\\Users\\runneradmin\\.cargo\\registry\\src\\index.crates.io-1949cf8c6b5b557f\\zenoh-1.9.0\\src\\api\\builders\\close.rs:124."}
-    :ok = Zenohex.Session.close(session_id)
+    assert {:ok, _session_id} = Zenohex.Session.open()
   end
 
   test "open/1" do
-    assert {:ok, session_id} =
+    assert {:ok, _session_id} =
              Zenohex.Config.default()
              |> Zenohex.Test.Support.TestHelper.scouting_delay(0)
              |> Zenohex.Session.open()
-
-    # Use explicit cleanup here because relying on Drop was flaky on Windows CI.
-    # Without this, Windows CI intermittently failed with the following error:
-    #
-    #   ** (MatchError) no match of right hand side value:
-    #   {:error,
-    #    "native/zenohex_nif/src\\session.rs:282: close operation timed out! at
-    #    C:\\Users\\runneradmin\\.cargo\\registry\\src\\index.crates.io-1949cf8c6b5b557f\\zenoh-1.9.0\\src\\api\\builders\\close.rs:124."}
-    :ok = Zenohex.Session.close(session_id)
   end
 
   test "close/1" do


### PR DESCRIPTION
revert commit 11d3cc4
discussed in https://github.com/biyooon-ex/zenohex/pull/200#issuecomment-4414908533