### PR TITLE
Pre-Release v0.9.1-beta.1

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Zenohex.MixProject do
   use Mix.Project
 
-  @version "0.9.0"
+  @version "0.9.1-beta.1"
   @source_url "https://github.com/biyooon-ex/zenohex"
 
   def project do

--- a/native/zenohex_nif/Cargo.lock
+++ b/native/zenohex_nif/Cargo.lock
@@ -4122,7 +4122,7 @@ dependencies = [
 
 [[package]]
 name = "zenohex_nif"
-version = "0.9.0"
+version = "0.9.1-beta.1"
 dependencies = [
  "log",
  "rustler",

--- a/native/zenohex_nif/Cargo.toml
+++ b/native/zenohex_nif/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zenohex_nif"
-version = "0.9.0"
+version = "0.9.1-beta.1"
 authors = []
 edition = "2021"
 


### PR DESCRIPTION
Since several useful features have been added after v0.9.0, this version is being published as a pre-release (marked as "Set as a pre-release" on the Releases page). 
Note that the compatible Zenoh version remains v1.9.0.