### PR TITLE
Bump Elixir and Erlang versions with release automation support

### DIFF
--- a/.github/workflows/code-analysis.yml
+++ b/.github/workflows/code-analysis.yml
@@ -1,8 +1,8 @@
 name: Code Analysis
 
 env:
-  OTP_VERSION: 27.3.4.2
-  ELIXIR_VERSION: 1.18.4
+  OTP_VERSION: 28.5
+  ELIXIR_VERSION: 1.19.5
   MIX_ENV: dev
 
 on:

--- a/.github/workflows/release-automation.yml
+++ b/.github/workflows/release-automation.yml
@@ -108,8 +108,8 @@ jobs:
     permissions:
       contents: write
     env:
-      OTP_VERSION: 27.3.4.2
-      ELIXIR_VERSION: 1.18.4
+      OTP_VERSION: 28.5
+      ELIXIR_VERSION: 1.19.5
     steps:
       - name: Checkout source code
         uses: actions/checkout@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,8 @@
 name: Test
 
 env:
-  OTP_VERSION: 27.3.4.2
-  ELIXIR_VERSION: 1.18.4
+  OTP_VERSION: 28.5
+  ELIXIR_VERSION: 1.19.5
   MIX_ENV: test
 
 on:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,6 @@
 name: Test
 
 env:
-  OTP_VERSION: 28.5
-  ELIXIR_VERSION: 1.19.5
   MIX_ENV: test
 
 on:
@@ -14,7 +12,7 @@ on:
 
 jobs:
   test:
-    name: mix test (${{ matrix.os }})
+    name: mix test (${{ matrix.os }}, OTP ${{ matrix.beam.otp_version }}, Elixir ${{ matrix.beam.elixir_version }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -24,6 +22,13 @@ jobs:
           - ubuntu-24.04
           - macos-26
           - windows-2022
+        beam:
+          - otp_version: 27.3.4.2
+            elixir_version: 1.18.4
+          - otp_version: 28.5
+            elixir_version: 1.19.5
+          - otp_version: 29.0.1
+            elixir_version: 1.20.0
 
     steps:
       - uses: actions/checkout@v6
@@ -31,8 +36,8 @@ jobs:
       - uses: erlef/setup-beam@v1
         id: setup-beam
         with:
-          otp-version: ${{ env.OTP_VERSION }}
-          elixir-version: ${{ env.ELIXIR_VERSION }}
+          otp-version: ${{ matrix.beam.otp_version }}
+          elixir-version: ${{ matrix.beam.elixir_version }}
 
       - name: Cache mix deps
         id: deps-cache

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   test:
-    name: mix test (${{ matrix.os }}, OTP ${{ matrix.beam.otp_version }}, Elixir ${{ matrix.beam.elixir_version }})
+    name: mix test (${{ matrix.os }}, Elixir ${{ matrix.beam.elixir_version }}, OTP ${{ matrix.beam.otp_version }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.18.4-otp-27
-erlang 27.3.4.2
+elixir 1.19.5-otp-28
+erlang 28.5

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ Please also check the description on [Releases](https://github.com/biyooon-ex/ze
 
 FYI, the development team currently uses the following versions.
 
-- Elixir 1.18.4-otp-27
-- Erlang/OTP 27.3.4.2
+- Elixir 1.19.5-otp-28
+- Erlang/OTP 28.5
 - Rust 1.93.0
 
 ### Installation

--- a/test/version_match_test.exs
+++ b/test/version_match_test.exs
@@ -1,32 +1,33 @@
 defmodule Zenohex.VersionMatchTest do
   use ExUnit.Case
 
-  describe "CI" do
+  defp tool_versions_map do
+    File.read!(".tool-versions")
+    |> String.split("\n")
+    |> Enum.reduce(%{}, fn line, acc ->
+      cond do
+        String.contains?(line, "erlang") ->
+          [_, version] = String.split(line, " ")
+          Map.put(acc, :erlang, version)
+
+        String.contains?(line, "elixir") ->
+          [_, version] = String.split(line, " ")
+          [version, "otp", _] = String.split(version, "-")
+          Map.put(acc, :elixir, version)
+
+        true ->
+          acc
+      end
+    end)
+  end
+
+  describe "Elixir/Erlang" do
     for filename <- [
           "code-analysis.yml",
           "test.yml",
           "release-automation.yml"
         ] do
       test "#{filename} version match" do
-        tool_versions_map =
-          File.read!(".tool-versions")
-          |> String.split("\n")
-          |> Enum.reduce(%{}, fn line, acc ->
-            cond do
-              String.contains?(line, "erlang") ->
-                [_, version] = String.split(line, " ")
-                Map.put(acc, :erlang, version)
-
-              String.contains?(line, "elixir") ->
-                [_, version] = String.split(line, " ")
-                [version, "otp", _] = String.split(version, "-")
-                Map.put(acc, :elixir, version)
-
-              true ->
-                acc
-            end
-          end)
-
         ciyaml_versions_map =
           File.read!(".github/workflows/#{unquote(filename)}")
           |> String.split("\n")
@@ -45,13 +46,37 @@ defmodule Zenohex.VersionMatchTest do
             end
           end)
 
-        assert tool_versions_map.erlang == ciyaml_versions_map.erlang
-        assert tool_versions_map.elixir == ciyaml_versions_map.elixir
+        assert tool_versions_map().erlang == ciyaml_versions_map.erlang
+        assert tool_versions_map().elixir == ciyaml_versions_map.elixir
       end
+    end
+
+    test "README version match" do
+      readme_versions_map =
+        File.read!("README.md")
+        |> String.split("\n")
+        |> Enum.reduce(%{}, fn line, acc ->
+          cond do
+            String.starts_with?(line, "- Elixir ") ->
+              [_, version] = String.split(line, "- Elixir ")
+              [elixir_version, "otp", _] = String.split(version, "-")
+              Map.put(acc, :elixir, elixir_version)
+
+            String.starts_with?(line, "- Erlang/OTP ") ->
+              [_, version] = String.split(line, "- Erlang/OTP ")
+              Map.put(acc, :erlang, version)
+
+            true ->
+              acc
+          end
+        end)
+
+      assert tool_versions_map().erlang == readme_versions_map.erlang
+      assert tool_versions_map().elixir == readme_versions_map.elixir
     end
   end
 
-  describe "Elixir/Rust" do
+  describe "Rust" do
     test "package version match" do
       version_on_mix_exs =
         Mix.Project.config()
@@ -82,7 +107,18 @@ defmodule Zenohex.VersionMatchTest do
       rust_version_on_toml =
         Toml.decode_file!("native/zenohex_nif/rust-toolchain.toml")["toolchain"]["channel"]
 
+      rust_version_on_readme =
+        File.read!("README.md")
+        |> String.split("\n")
+        |> Enum.find_value(fn line ->
+          if String.starts_with?(line, "- Rust ") do
+            [_, version] = String.split(line, "- Rust ")
+            version
+          end
+        end)
+
       assert rust_version_on_yaml == rust_version_on_toml
+      assert rust_version_on_readme == rust_version_on_toml
     end
   end
 end

--- a/test/version_match_test.exs
+++ b/test/version_match_test.exs
@@ -2,7 +2,11 @@ defmodule Zenohex.VersionMatchTest do
   use ExUnit.Case
 
   describe "CI" do
-    for filename <- ["code-analysis.yml", "test.yml"] do
+    for filename <- [
+          "code-analysis.yml",
+          "test.yml",
+          "release-automation.yml"
+        ] do
       test "#{filename} version match" do
         tool_versions_map =
           File.read!(".tool-versions")

--- a/test/version_match_test.exs
+++ b/test/version_match_test.exs
@@ -21,10 +21,31 @@ defmodule Zenohex.VersionMatchTest do
     end)
   end
 
+  defp beam_versions_list do
+    File.read!(".github/workflows/test.yml")
+    |> String.split("\n")
+    |> Enum.reduce({[], nil}, fn line, {pairs, current_otp} ->
+      cond do
+        String.contains?(line, "otp_version:") ->
+          [_, version] = String.split(line, ":")
+          {pairs, String.trim(version)}
+
+        String.contains?(line, "elixir_version:") and current_otp != nil ->
+          [_, version] = String.split(line, ":")
+          pair = %{erlang: current_otp, elixir: String.trim(version)}
+          {[pair | pairs], nil}
+
+        true ->
+          {pairs, current_otp}
+      end
+    end)
+    |> elem(0)
+    |> Enum.reverse()
+  end
+
   describe "Elixir/Erlang" do
     for filename <- [
           "code-analysis.yml",
-          "test.yml",
           "release-automation.yml"
         ] do
       test "#{filename} version match" do
@@ -49,6 +70,10 @@ defmodule Zenohex.VersionMatchTest do
         assert tool_versions_map().erlang == ciyaml_versions_map.erlang
         assert tool_versions_map().elixir == ciyaml_versions_map.elixir
       end
+    end
+
+    test "test.yml includes current tool versions in beam matrix" do
+      assert tool_versions_map() in beam_versions_list()
     end
 
     test "README version match" do


### PR DESCRIPTION
- 開発向けバージョンを Elixir 1.19.5 / Erlang 28.5 に bump 
- CI 高速化が安定してきたので Elixir/Erlang 組を複数対応